### PR TITLE
Fix arrow operator for collections,

### DIFF
--- a/nodes/iternodes.py
+++ b/nodes/iternodes.py
@@ -298,21 +298,24 @@ class Append(Expression):
         self.src = src
 
     def do(self, ctx:Context):
-        # key, val for DictVal. src should be a tuple
+        # key, val for DictVal. src should be a tuple or dict
         dprint('Append do:', self.target, self.src)
-        key, val = None, None
-        if isinstance(self.src, TupleVal):
-            src = self.src.elems
-            k, v = src
-            key = var2val(k)
-        else:
-            v = self.src
-        val = var2val(v)
         
         if isinstance(self.target, ListVal):
+            v = self.src
+            val = var2val(v)
             self.target.addVal(val)
         elif isinstance(self.target, DictVal):
-            self.target.setVal(key, val)
+            if isinstance(self.src, TupleVal):
+                src = self.src.elems
+                k, v = src
+                key = var2val(k)
+                val = var2val(v)
+                self.target.setVal(key, val)
+            elif isinstance(self.src, DictVal):
+                for key, val in self.src.data.items():
+                    # print('dd:', key, val)
+                    self.target.data[key] = val
 
 
 class LeftArrowExpr(Expression):

--- a/readme.md
+++ b/readme.md
@@ -327,20 +327,53 @@ dd['c'] = 3
 print(dd['a'], ddd['b'])
 ```
 
-### 9. arrow-append/set operator `<-`
+### 9.1 arrow-append/set operator `<-`
+Left-arrow with list or dict in the right operand  puts value into collection.  
+(not in `for` statement or sequence generator)  
+For list it appends new value; `list <- val`  
+For dict it sets or updates value by key from passed tuple with `dict <- (val, key)`.  
 ```
-# list: append val
+# list:
 nn = []
 nn <- 12
 
-# dict: set val by key
-dictVar <- (key, val) # the same as dictVar[key] = val
+# dict:
+# 
 
 dd = {'b': 444}
 dd <- ('a', 123)
 dd <- ('b', 555)
 
 >> {'b': 555, 'a': 123}
+```
+```
+dict <- (key, val) 
+# the same as 
+dict[key] = val
+```
+For dicts we can set multiple pairs of key-value by the dict in the right operand: `dict <- dict`
+```
+res = {'a':11, 'b':22} # new dict
+
+res <- {'c': 44, 'b':33} # add / update vals
+
+>> {'a':11, 'b':33, 'c': 44}
+```
+
+### 9.2 Minus key `- [key]` (delete) operator
+Minus operator for collections.  
+Operator removes element by index | key and returns value of element.  
+For list:
+```
+a1 = [1,2,3]
+r1 = a1 - [1] # returns 2
+>> [1,3]
+```
+For dict:
+```
+d2 = {'a':11, 'b':22}
+r2 = d2 - ['a'] # returns 11
+>> {'b': 22}
 ```
 
 ### 10. Struct.  

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -34,12 +34,12 @@ class TestDev(TestCase):
         for i <- vals
             if cond(i)
                 return i
-
     con = x -> x > 4
     vals = [1..10]
     r5 = br(vals, con)
     print('r5', r5)
     '''
+
 
     def _test_barr(self):
         ''' '''
@@ -58,6 +58,8 @@ class TestDev(TestCase):
         ex.do(ctx)
         rvar = ctx.get('res')
         self.assertEqual(0, rvar.getVal())
+        rvar = ctx.get('res').get()
+        self.assertEqual([], rvar.vals())
 
     def _test_match_for_if_same_line(self):
         ''' TODO: match with for loop, `if` statement in the same case line

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -22,6 +22,52 @@ class TestLists(TestCase):
     ''' Testing lists, iterators, generators, other collections '''
 
 
+    def test_put_dict_in_dict(self):
+        '''
+        dictVar <- (key, val)
+        dictVar <- {key: val, key: val}
+        '''
+        code = r'''
+        res = {'a':11, 'd':44}
+        
+        res <- ('b', 22)
+        res <- {'c': 33}
+        res <- {'e': 55, 'd':41}
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+
+        tlines = splitLexems(code)
+        clines:CLine = elemStream(tlines)
+        ex = lex2tree(clines)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        ex.do(ctx)
+        rvar = ctx.get('res').get()
+        self.assertEqual({'a':11, 'b':22, 'c': 33, 'd': 41, 'e': 55}, rvar.vals())
+
+    def test_put_tuple_in_list(self):
+        ''' lastVal <- (tuple, val) '''
+        code = r'''
+        res = []
+        
+        res <- 1
+        res <- (2,3)
+        res <- (4,5)
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+
+        tlines = splitLexems(code)
+        clines:CLine = elemStream(tlines)
+        ex = lex2tree(clines)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        ex.do(ctx)
+        rvar = ctx.get('res').get()
+        self.assertEqual([1, (2, 3), (4, 5)], rvar.vals())
 
     def test_slice_of_generator(self):
         ''' # TODO: nn = [1..10]; nn5 = nn[1:5] '''
@@ -138,8 +184,10 @@ class TestLists(TestCase):
         exp = [-2, -1, 0, 1, 2]
         self.assertEqual(exp, rvar.vals())
 
-    def test_barr_del_collection_elem_minus(self):
-        ''' '''
+    def test_del_collection_elem_minus(self):
+        ''' minus operator for collections key
+            removes element by index and returns value of element
+        '''
         code = r'''
         
         res = []

--- a/tests/test_multicall.py
+++ b/tests/test_multicall.py
@@ -26,10 +26,10 @@ from strformat import *
 from tests.utils import *
 
 
-def ivar(name, value):
-    vv = Var(name, TypeInt())
-    vv.set(Val(value, TypeInt()))
-    return vv
+# def ivar(name, value):
+#     vv = Var(name, TypeInt())
+#     vv.set(Val(value, TypeInt()))
+#     return vv
 
 
 class TestMulticall(TestCase):

--- a/todo.et
+++ b/todo.et
@@ -76,6 +76,8 @@
     # if function not just defined name but result of expression: (lambda)(), funcs[key](), foo()()
     # func should be an expression which returns function object
 
+20. DONE Issue: listVar <- (tuple, item) works not correct
+
 
 # Perspective things: 
 1. Maybe type 


### PR DESCRIPTION
Fix append tuple to list by `<-` operator. 
Add dict as a right operand for `dict <- val` case. 
Add `collection - [key]` case to readme.
```
>py -m unittest
Ran 148 tests in 0.858s>
OK
```