### PR TITLE
Test of arrow-append, test of types.

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -24,8 +24,8 @@ def rootContext(ctx:Context = None)->RootContext:
     setNativeFunc(ctx, 'join', built_join, TypeAny)
     
     constants = {
-    'true': (TypeBool, Val(True, TypeBool)),
-    'false': (TypeBool, Val(False, TypeBool)),
+    'true': (TypeBool, Val(True, TypeBool())),
+    'false': (TypeBool, Val(False, TypeBool())),
     }
     for name, cn in constants.items():
         vv = Var(name, cn[0], const=True)

--- a/nodes/builttins.py
+++ b/nodes/builttins.py
@@ -64,9 +64,11 @@ def built_len(_, arg):
 def built_int(_, x):
     return Val(int(x.getVal()), TypeInt())
 
-def built_type(_, val):
+def built_type(_, val:Val|Var):
     # TODO: add more correct type identification
-    return Val(type(val.getVal()), TypeType())
+    # print('bltype:', val,  type(val), val.getType())
+    # return Val(type(val.getType()), TypeType())
+    return Val(val.getType(), TypeType())
 
 
 def built_list(_, src):

--- a/nodes/control.py
+++ b/nodes/control.py
@@ -45,7 +45,7 @@ class IfExpr(ControlBlock):
         self.curBlock = self.mainBlock
 
     def setCond(self, expr:Expression, subExp:list[Expression]=[]):
-        dprint('#IfExpr setCond ', expr, subExp)
+        # dprint('#IfExpr setCond ', expr, subExp)
         self.cond = expr
         self.preSubs = subExp
     
@@ -57,7 +57,8 @@ class IfExpr(ControlBlock):
         self.curBlock = self.elseBlock
 
     def do(self, ctx:Context):
-        dprint('# IfExpr.do1 ', self.cond, type(self.cond))
+        # print('# IfExpr.do1 ', self.cond, type(self.cond), ' | src:', self.cond.src)
+        # print(' | src:', self.cond.src)
         inCtx = Context(ctx)
         for sub in self.preSubs:
             sub.do(inCtx)
@@ -65,19 +66,19 @@ class IfExpr(ControlBlock):
         target:Block = self.mainBlock
         self.lastRes = None
         condRes = self.cond.get()
-        dprint('# IfExpr.do02 ', condRes, type(condRes))
-        dprint('## Cond-get', condRes, condRes.get())
+        # print('# IfExpr.do02 ', condRes, type(condRes))
+        # print('## Cond-get', condRes, condRes.get())
         if not condRes.get():
-            dprint('## IF_ELSE')
+            # dprint('## IF_ELSE')
             if not self.elseBlock:
                 # if don't have else-block return from if-block without result
                 return
             # enter to else-block
             target = self.elseBlock
-        dprint('# IfExpr.do2 ', target)
+        # dprint('# IfExpr.do2 ', target)
         target.do(inCtx)
         self.lastRes = target.get() # for case if we need result from if block or one-line-if
-        dprint('# IfExpr.do2 ', self.lastRes)
+        # dprint('# IfExpr.do2 ', self.lastRes)
 
     def get(self):
         return self.lastRes

--- a/nodes/datanodes.py
+++ b/nodes/datanodes.py
@@ -185,7 +185,8 @@ class TupleExpr(CollectionExpr):
         self.obj = TupleVal()
         for exp in self.valsExpr:
             exp.do(ctx)
-            self.obj.addVal(exp.get())
+            v = exp.get()
+            self.obj.addVal(var2val(v))
 
     def get(self):
         return self.obj

--- a/nodes/iternodes.py
+++ b/nodes/iternodes.py
@@ -402,7 +402,7 @@ class EmptyFilter(Expression):
         pass
     
     def get(self) -> Var|list[Var]:
-        return Val(True, TypeBool)
+        return Val(True, TypeBool())
 
 
 class ListComprExpr(Expression):

--- a/nodes/oper_nodes.py
+++ b/nodes/oper_nodes.py
@@ -27,7 +27,7 @@ class OperCommand(Expression):
         # self._block = False
 
     def get(self):
-        # dprint('# -> OperCommand.get() ', self.oper, self.res)
+        # print('# -> OperCommand.get() ', self.oper, self.res)
         return self.res
 
     # def isBlock(self)->bool:
@@ -350,7 +350,7 @@ class OpBinBool(BinOper):
         #     return False
         res = ff[self.oper](a.getVal(), b.getVal())
         dprint('# == == OpCompare.do ', res)
-        self.res = Val(res, TypeBool)
+        self.res = Val(res, TypeBool())
     
     def op_and(self, a, b):
         return a and b
@@ -391,7 +391,7 @@ class OpCompare(BinOper):
             pass
         res = ff[self.oper](a.getVal(), b.getVal())
         # dprint('# == == OpCompare.do ', res)
-        self.res = Val(res, TypeBool)
+        self.res = Val(res, TypeBool())
 
 
     def eq(self, a, b):
@@ -430,10 +430,15 @@ class OpBitwise(BinOper):
         self.right.do(ctx)
         # get val objects from expressions
         a, b = self.left.get(), self.right.get()
+        # print('OpBitwise ():', self.oper)
+        # print('self.left, self.right = ', self.left, self.right)
+        # print('a, b : ', a, b)
+        # print('types: : ', a.getType(), b.getType())
         type = a.getType()
-        if type != b.getType():
-            # TODO type??
-            return False
+        # if type != b.getType():
+        #     # TODO type??
+        #     self.res = Val(False, TypeBool())
+        #     return False
         res = ff[self.oper](a.getVal(), b.getVal())
         self.res = Val(res, a.getType())
 

--- a/readme.md
+++ b/readme.md
@@ -166,16 +166,25 @@ d=3
 res = 5 + 6 - 7*(b - c * 12 - 15) / 11 + 3 ** d - 0xe * 8
 ```
 Other unary operators.  
-`!` logical NOT
-`~` bitwise NOT
+`!` logical NOT  
+`~` bitwise NOT  
 
+Operators with assignment   
+`+=` `-=` `*=` `/=` `%=` 
 ```
-# operators with assignment
 x = 1
 x += 2
-x *=3
-x %= 2
 ```
+Bitwise:   
+`&` `|` `^` `<<` `>>` `~`
+Compare:  
+`==` `!=` `>` `<` `>=` `<` `<=`
+Logical:
+`&&` `||` `!` 
+Other:  
+`?>` `!?>` `?:` `<-` `->` `!-`
+
+
 
 ### 5. Collections: list (array), tuple, dict (map)
 ```
@@ -236,13 +245,12 @@ for i=0; i < 5; i = i + 1
 res = y
 ```
 
-- Iterator, arrow-assign operator `<-`
-`<-` operator have several options.  
-Here we explain arrow as an iterative assignment.  
+- Iterator, arrow-assign operator `<-`  
+Left-arrow `<-` operator has several options.  
+Here we use left-arrow as an iterative assignment in `for` statement.  
+It looks, like we pick the element from the sequence one-by-one.
 ```
 # by function iter
-# iter(last+1)
-# iter(start, last+1 [, step])
 arr = [1,2,3]
 r = 0
 for i <- iter(3)
@@ -261,7 +269,19 @@ for x <- [1..10]
 for k, val <- {'a':1, 'b':2}
     ...
 ```
-Keywords `continue`, `break`
+Function `iter()`  
+```
+# One arg iter(last+1)
+iter(3) # >> 0,1,2
+
+# more args iter(start, last+1 [, step])
+iter(1, 5) # >> 1,2,3,4
+
+iter(1,7,2) # >> 1,3,5
+
+```
+
+Keywords `continue`, `break`.  
 
 ```
 r = []

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -311,16 +311,16 @@ class TestControl(TestCase):
         dprint('#t >>> r:', r1)
 
     def test_if_else(self):
-        code = '''
-        res = 100
-        if x >= 10 | x < 2 && x != 0
-            res = 2000 + x * -10 - 700
-        else
-            x = x ** 2
-            res = 1000 + x - 500
-            # if res < 500
-            #     res = res + 10000
-        '''
+        # code = '''
+        # res = 100
+        # if x >= 10 | x < 2 && x != 0
+        #     res = 2000 + x * -10 - 700
+        # else
+        #     x = x ** 2
+        #     res = 1000 + x - 500
+        #     # if res < 500
+        #     #     res = res + 10000
+        # '''
         code = '''
         res = 100
         # y = 0
@@ -341,6 +341,7 @@ class TestControl(TestCase):
         code = norm(code[1:])
         data = [0, 1, 4, 5, 10, 20, 30, 40, 100, 200]
         # data = [10, 20]
+        # lang.FullPrint = 1
         tlines = splitLexems(code)
         clines:CLine = elemStream(tlines)
         ex = lex2tree(clines)
@@ -350,7 +351,7 @@ class TestControl(TestCase):
             vv = Var('x', TypeInt)
             vv.set(Val(x, TypeInt))
             ctx.addSet({'x': vv})
-            dprint('~~~~ test case: %d ~~~~' % x)
+            print('~~~~ test case: %d ~~~~' % x)
             ex.do(ctx)
             ress.append(ctx.get('res').get())
             dprint('##################t-IF1:', ctx.get('res').get())

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -3,6 +3,7 @@
 
 from unittest import TestCase, main
 
+import typex
 from lang import Lt, Mk, CLine
 from parser import splitLine, splitLexems, charType, splitOper, elemStream
 from vars import *
@@ -26,7 +27,6 @@ class TestDev(TestCase):
 
     # TODO: type of struct field: list, dict, bool, any
     
-    # TODO: add tuple into list by `<-`
 
     '''
     # pseudo-break
@@ -38,6 +38,13 @@ class TestDev(TestCase):
     vals = [1..10]
     r5 = br(vals, con)
     print('r5', r5)
+    '''
+
+    '''
+        # user defined types
+        struct ABC a: int, b: int
+        abc = ABC{a:1, b:2}
+        res <- type(abc)
     '''
 
 

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -22,6 +22,36 @@ class TestLists(TestCase):
     ''' Testing lists, iterators, generators, other collections '''
 
 
+
+    def test_arrow_append_when_func_call_left(self):
+        ''' For left-arrow operator target is result of function call 
+        (returns collection).
+        '''
+        code = r'''
+        res = []
+        
+        func foo()
+            res
+        
+        func bar(x)
+            (x, x * 10)
+        
+        foo() <- bar(2)
+        foo() <- bar(3)
+        
+        print('res = ', res)
+        '''
+        code = norm(code[1:])
+
+        tlines = splitLexems(code)
+        clines:CLine = elemStream(tlines)
+        ex = lex2tree(clines)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        ex.do(ctx)
+        rvar = ctx.get('res').get()
+        self.assertEqual([(2, 20), (3, 30)], rvar.vals())
+
     def test_put_dict_in_dict(self):
         '''
         dictVar <- (key, val)

--- a/tests/test_vals.py
+++ b/tests/test_vals.py
@@ -1,0 +1,87 @@
+
+
+from unittest import TestCase, main
+
+import typex
+from lang import Lt, Mk, CLine
+from parser import splitLine, splitLexems, charType, splitOper, elemStream
+from vars import *
+from vals import numLex
+from context import Context
+from strformat import *
+from nodes.structs import *
+from tree import *
+from eval import rootContext, moduleContext
+
+from cases.utils import *
+from nodes.tnodes import Var
+from nodes import setNativeFunc, Function
+from tests.utils import *
+
+import pdb
+
+
+class TestVals(TestCase):
+
+
+
+    def test_builtin_type(self):
+        ''' For left-arrow operator target is result of function call 
+        (returns collection).
+        '''
+        code = r'''
+        res = []
+        
+        # vals
+        res <- type(1)
+        res <- type(0x15)
+        res <- type(2.3)
+        res <- type(false)
+        res <- type("string!")
+        
+        # # vars
+        i, yy, nl = 11, true, null
+        res <- type(i)
+        res <- type(yy)
+        res <- type(nl)
+        
+        #collections
+        lval, dval, tval = [1,2,3], {4:5}, (6, 7)
+        res <- type(lval)
+        res <- type(dval)
+        res <- type(tval)
+        
+        # print('res = ', res)
+        
+        '''
+        code = norm(code[1:])
+
+        tlines = splitLexems(code)
+        clines:CLine = elemStream(tlines)
+        ex = lex2tree(clines)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        ex.do(ctx)
+        rvar = ctx.get('res').get()
+        res = rvar.vals()
+        rtypes = [n.__class__ for n in res]
+        # print('RTP:', rtypes)
+        # print('RVL:', res)
+        exp = [
+            typex.TypeInt,
+            typex.TypeInt,
+            typex.TypeFloat,
+            typex.TypeBool,
+            typex.TypeString,
+            typex.TypeInt,
+            typex.TypeBool,
+            typex.TypeNull,
+            typex.TypeList,
+            typex.TypeDict,
+            typex.TypeTuple,
+        ]
+        self.assertEqual(exp, rtypes)
+
+
+if __name__ == '__main__':
+    main()

--- a/todo.et
+++ b/todo.et
@@ -37,10 +37,22 @@
 10 serialization: 
     1) data objects (collections, struct inst) 
     2) executive tree (prepared exec file)
-11. struct constructor without field names: A{1, 2.0, 'abc'} - order-driven struct constructor.
-11.2 named args for function: func foo(name:string) # call: foo(name:'Abc')
-12. Interfaces as a some list of method signatures.
-13. other args in `func(a, b, other...) : foo(1, 2, 33, 44, 55, 66, 77) other = [33, 44, 55, 66, 77]
+11. Struct constructor
+    - constructor without field names: A{1, 2.0, 'abc'} - order-driven struct constructor.
+    - method-constructor for struct :: thinkable.
+        `TypeName.(a, b, c)` instead of positional-args constructor
+        `TypeName{a, b, c}`. Looks more flexible
+        note: it have to be implemented (instead of `T{...}`) but we can make default implementation by order of fields in definition
+12.1 named args for function: func foo(name:string) # call: foo(name:'Abc')
+12.2 other args in `func(a, b, other...) : foo(1, 2, 33, 44, 55, 66, 77) other = [33, 44, 55, 66, 77]
+12.3 default values of args func foo(x, y=3) :: needed
+12.xx other possible extensions of basic scheme of function:
+    - undeclared args passed by name (like kwargs in python):: thinkable
+    - function / method overload: totally not applicable to strategy of floating number of args like default-val and named-args / No.
+    - shortening syntax with obvious-arg in lambda (like scala) `x -> x + 2` => `_ * 2`: not necessary but :: thinkable
+    - unused/unnamed var `_` for function args foo(_, x), multiple assignment `for key, _ <- dict`:: thinkable
+
+13. Interfaces as a some list of method signatures.
 14. # DEPRACATE match-case block start in the same line: # It looks as over-sugaring # 
     match n
         1 !- if cond
@@ -77,6 +89,21 @@
     # func should be an expression which returns function object
 
 20. DONE Issue: listVar <- (tuple, item) works not correct
+
+21. # Refuse ` var <- sequence` out of `for` statement.
+    looks like it will provoke not clear interpretation like redefinition of listVar in `listVar <- list`.
+
+21.1 reading itertor. read values from sequence in the loop iteration like 
+    val = iter(src) # src is collection or generator
+        it should init iterator and save instance in first call, then call next() method in each iteration
+        it should have reset() method
+        # sugar: val <= src // ?
+
+22. append meany values to list `res <- vals`, like dict has
+    looks like `list += [a, b, c]` looks ok
+
+
+
 
 
 # Perspective things: 
@@ -269,6 +296,21 @@ func foo(arg)
 
 @#
 
+## 
+#### thinking :
+ -- read from list to list in one expression
+for i <- src
+    res <-  i
+
+for i <- src :: res <-  i
+
+for res: <- src
+
+[_ ; x <- src; res <- x]
+the same
+
+res = [x; x <- src]
+# No sense.
 #@
 ########################### Done section ############################# 
 @#

--- a/vals.py
+++ b/vals.py
@@ -88,7 +88,7 @@ def elem2val(elem:Elem)->Var:
         return Val(elem.text, TypeString())
     if elem.type == Lt.word:
         if elem.text in bool_constants:
-            return Val(bool(elem.text), TypeBool)
+            return Val(bool(elem.text), TypeBool())
         if elem.text == 'null':
             return Val(Null(), TypeNull())
             


### PR DESCRIPTION
Add tests of: 
builtin `type()`, 
case of arrow-append with functions: `foo() <- bar()`. 
Fix bool type, fix bitwise operators. 
Fix tuple.
Readme and notes.