### PR TITLE
Auto-preload modules.

### DIFF
--- a/build.py
+++ b/build.py
@@ -10,6 +10,7 @@ from lang import CLine, dprint
 from parser import splitLexems, elemStream
 from tree import lex2tree
 from nodes.expression import Expression
+from loader import *
 # from nodes.tnodes import Module
 
 
@@ -26,24 +27,25 @@ def getArgs():
     return args
 
 
-def readFile(filename):
-    '''return file content'''
-    fpath = filepath(filename)
-    with open(fpath, 'r') as fr:
-        return fr.read()
+# def readFile(filename):
+#     '''return file content'''
+#     fpath = filepath(filename)
+#     with open(fpath, 'r') as fr:
+#         return fr.read()
+    
 
+# def buildTree(src):
+#     '''Parse and build executable tree.'''
+#     tlines = splitLexems(src)
+#     clines:list[CLine] = elemStream(tlines)
+    
+#     exp = lex2tree(clines)
+#     return exp
 
-def buildTree(src):
-    '''Parse and build executable tree.'''
-    tlines = splitLexems(src)
-    clines:CLine = elemStream(tlines)
-    exp = lex2tree(clines)
-    return exp
-
-def buildFile(filename):
-    '''Read file and build exec tree'''
-    src = readFile(filename)
-    return buildTree(src)
+# def buildFile(filename):
+#     '''Read file and build exec tree'''
+#     src = readFile(filename)
+#     return buildTree(src)
 
 
 def tree2bin(expr:Expression):

--- a/cases/tcases.py
+++ b/cases/tcases.py
@@ -2,6 +2,8 @@
 ExpCases here for exec tree
 '''
 
+import os
+
 from lang import *
 from vars import *
 from vals import isDefConst, elem2val, isLex
@@ -491,14 +493,16 @@ class CaseImport(ExpCase):
     def expr(self, elems:list[Elem])-> tuple[Expression, Expression]:
         ''' return base expression, Sub(elems) '''
         # module = elems[0].text
+        # prels('>>', elems, show=1)
+        # lang.FullPrint = 0
         path, names = self.splitElems(elems[1:])
-        dprint('path, names::', path, names )
+        # print('path, names::', path, names )
         expr = ImportExpr(path, names)
         return expr
 
     def splitElems(self, elems:list[Elem])->tuple:
         path = []
-        prels('Import Case splitElems: ', elems)
+        # prels('ImportCase splitElems: ', elems)
         # imnames = []
         # inPath = True
         afterMore = False
@@ -533,7 +537,7 @@ class CaseImport(ExpCase):
         
         part = []
         remElems = elems[cnt:]
-        prels('Import Case splitElems2: ', remElems)
+        # prels('Import Case splitElems2: ', remElems)
         for ee in remElems:
             if isLex(ee, Lt.oper, ','):
                 # next name
@@ -547,3 +551,13 @@ class CaseImport(ExpCase):
             importList.append(part)
         return path, importList
 
+    def fileByPath(self, path:list[str]):
+        # print('fbp1:', path)
+        pathElems = path[:-1]
+        # dirPath = ''
+        fname = '%s.%s' % (path[-1], CODE_EXT)
+        pathElems.append(fname)
+        # if len(dirs) > 0:
+        #     dirPath = os.path.join(*dirs)
+        # print('fbp::', pathElems)
+        return os.path.join(*pathElems)

--- a/cases/utils.py
+++ b/cases/utils.py
@@ -63,7 +63,10 @@ def isBrPair(elems:list[Elem], opn, cls):
     return isLex(elems[0], Lt.oper, opn) and isLex(elems[-1], Lt.oper, cls)
 
 
-def prels(pref, elems:list[Elem], *args):
+def prels(pref, elems:list[Elem], *args, **kwargs):
+    if 'show' in kwargs and kwargs['show']:
+        print(pref, [n.text for n in elems], *args)
+        return
     dprint(pref, [n.text for n in elems], *args)
 
 

--- a/lang.py
+++ b/lang.py
@@ -4,6 +4,9 @@ Base types.
 
 import re
 
+
+CODE_EXT = 'et'
+
 # TODO: add config
 FullPrint = 0
 

--- a/loader.py
+++ b/loader.py
@@ -1,0 +1,94 @@
+
+'''
+Interpretation loader.
+'''
+
+
+from argparse import ArgumentParser
+import os
+from pathlib import Path
+
+from lang import CLine, dprint
+from parser import splitLexems, elemStream
+from tree import lex2tree
+from context import Context, ModuleContext, RootContext
+from cases.tcases import CaseImport
+from vals import isLex
+from nodes.expression import Expression
+from nodes.tnodes import Module
+from eval import rootContext
+
+
+cimp = CaseImport()
+rootCtx = rootContext()
+
+modRoot = ''
+
+def filePath(root, modFile):
+    return os.path.join(root, modFile)
+
+
+def getLibRoot():
+    # common store: used-defined dir with all installed liraries.
+    # can be defined by 
+    # config (TODO: add config) or 
+    # env var (TODO) or
+    # CI arg (TODO).
+    return ''
+
+
+def readFile(fpath):
+    '''return file content'''
+    # fpath = filepath(filename)
+    with open(fpath, 'r') as fr:
+        return fr.read()
+
+
+def buildFile(rctx: RootContext, path):
+    '''Read file and build exec tree'''
+    # print('buildFile:', path)
+    src = readFile(path)
+    return buildTree(src, rctx)
+
+
+def modPreload(rctx: RootContext, modPath:str, root=None, name = ''):
+    rootPath = modRoot # TODO: 1) local dir, 2) common store 
+    if root:
+        rootPath = root
+    # print('modPreload:', rootPath, modPath)
+    fpath = os.path.join(rootPath, modPath)
+    mod = buildFile(rctx, fpath)
+    mod.name = name
+    rctx.loadModule(mod)
+    return mod
+
+
+def loadModules(lines:list[CLine], rctx:RootContext):
+    ''' TODO: we have to detect `import` command and preload importing modules here.
+    Looks like we need to use for preloading the same mechanism because
+    declaretions of structs need to be loaded into context 
+    before correct interpretation of structs contructors.
+    '''
+    for s in lines:
+        if cimp.match(s.code):
+            # parse import line
+            impPath, _ = cimp.splitElems(s.code[1:])
+            modName = impPath[-1]
+            # print('impPath:', impPath)
+            fpath = cimp.fileByPath(impPath)
+            # load module
+            modPreload(rctx, fpath, name=modName)
+
+
+def buildTree(src, rctx: RootContext=None):
+    '''Parse and build executable tree.
+    rctx: RootContext - not needed if no imports in source code
+    '''
+    tlines = splitLexems(src)
+    clines:list[CLine] = elemStream(tlines)
+    # rootCtx = rootContext()
+    loadModules(clines, rctx)
+    exp = lex2tree(clines)
+    return exp
+
+

--- a/nodes/expression.py
+++ b/nodes/expression.py
@@ -409,13 +409,17 @@ class SFormatter:
     def formatString(self, code:str):
         pass
 
-def expSrc(expr:Expression):
+def expSrc(expr:Expression|ParseErr|InterpretErr):
     exsrc = '-=-'
-    if expr.src:
+    if expr and expr.src:
         if isinstance(expr.src, str):
             exsrc = expr.src
+        if isinstance(expr.src, TLine):
+            exsrc = expr.src.src
         elif isinstance(expr.src, CLine):
             exsrc = expr.src.src.src
         else:
             exsrc = str(expr.src)
+    if expr is None:
+        exsrc = 'None_src'
     return "`%s`" % exsrc

--- a/nodes/tnodes.py
+++ b/nodes/tnodes.py
@@ -66,7 +66,7 @@ class ImportExpr(Expression):
     def __init__(self, path, elems:list[list[str]], src = ''):
         super().__init__(None, src)
         self.fullImport = False
-        # dprint('ImportExpr __init:', elems)
+        # print('ImportExpr __init:', elems)
         if (len(path) > 1 and path[-1] == '*' and len(elems) == 0):
             self.fullImport = True
             path = path[:-1]

--- a/readme.md
+++ b/readme.md
@@ -24,15 +24,15 @@ Content:
 6. [For-statement: `for i <- [1..5]`](#6-for-statement---operator)
 7. [Functions:`func foo()`](#7-function-definition-context-of-functions)
 8. [Dict](#8-dict-linear-and-block-constructor)
-9. 
-    1. [Collection: append `nums <- 15`](#91-arrow-appendset-operator--)
-    2. [Collection: minus `- [key]`](#92-minus-key---key-delete-operator)
-10. Struct type: 
+9. Collection features:
+    1. [append operator `nums <- 15`](#91-arrow-appendset-operator--)
+    2. [deletion operator `data - [key]`](#92-minus-key---key-delete-operator)
+10. Struct: 
     1. [Definition, constructor, fields](#10-struct)
-11. Struct details:
+11. Struct OOP:
     1. [Struct: methods](#111-struct-method)
     2. [Struct: inheritance](#112-struct-inheritance-multiple-inheritance-is-allowed)
-12. List:
+12. List features:
     1. [Slice, iteration generator: `[ : ]`, `[ .. ]`](#121-list-features-slice-iteration-generator-tolist)
     1. [Sequence generator `[ ; ; ]`](#122-list-comprehension--sequence-generator)
 13. [Multiline esxpressions](#13-multiline-expressions-if-for-math-expr)
@@ -68,44 +68,82 @@ Basic principles.
 *
 
 ## Usage.
+Note: `python run` command is one line, splitted in examples just for readability. 
 ```
 # run file
 python -m run tests/simple_test.et
 ...
 
 # run code line
+# -c --codeline
 python -m run -c "a = 2; b = a + 1"
 
-# with print
+# with print function
 python -m run -c "r = [1..5]; print('nums:', tolist(r))"
 nums: [1, 2, 3, 4, 5]
 ...
 
 # more complex 1-line example:
-python -m run -c "f1 = (x, y) -> x + y; f2 = x -> x * x;  p = x -> print(x); [p(f1(f2(n), 10000)); n <- [1..10]; n % 2 > 0 && n > 3]"
+python -m run 
+    -c "f1 = (x, y) -> x + y; f2 = x -> x * x;  p = x -> print(x); [p(f1(f2(n), 10000)); n <- [1..10]; n % 2 > 0 && n > 3]"
 10025
 10049
 10081
-
-# print result
+```
+Features of `run`.  
+```
+# show result
+# -r --result : name of resulting variable
 py -m run -c "res = 100 + 23" -r res
 >> 123
 
 # multirun - build once and run multiple times by dataset
 # json as a data source
+# -l --multirun
+# -s --datasource : LP-code produsing data
+# -f --json-file : file with data
+# -j --json-source : string with json
+
 # data: [{'a': 1, 'b': 2}, {'a': 3, 'b': 4}, {'a': 5, 'b': 6}]
-py -m run -c "n = a + b; print(':', a, b, n)" -l -j "[{\"a\":1, \"b\":2}, {\"a\":3, \"b\":4}, {\"a\":5, \"b\":6}]" -r n
+py -m run 
+    -c "n = a + b; print(':', a, b, n)" 
+    -l -j "[{\"a\":1, \"b\":2}, {\"a\":3, \"b\":4}, {\"a\":5, \"b\":6}]" 
+    -r n
 : 1 2 3
 : 3 4 7
 : 5 6 11
 >> 11
 
 ```
-See code of run.py, build.py, eval.py for understanding how to use LISAPET as an imbedded engine, add custom python functions for using in LP code, etc.  
+Impoting and root path.
+```
+# -p --pathroot
+# -i --import
+py -m run -p "tests" 
+    -i "tdata.st1 > Point2, f1"  
+    -c "pp = Point2{x:2, y:3}; a = pp.sum(); p = (f1(a))" 
+    -r p
+```
+Show error.  
+For some debug needs we can ask print native Traceback of error.  
+```
+# -e --show-error
+
+py -m run -c "1/0" -e
+Error handling:  division by zero
+Traceback (most recent call last):
+...
+  File "...\nodes\oper_nodes.py", line 277, in div
+    return a / b
+           ~~^~~
+ZeroDivisionError: division by zero
+```
+
+See code of run.py, loader.py, eval.py for understanding how to use LISAPET as an imbedded engine, add custom python functions for using in LP code, etc.  
 
 ## Syntax.
-
-Done parts:
+The Syntax section has been updated as new features have been added to the code, so it looks a bit chaotic.  
+Done parts:  
 
 ### 0. Comments.
 ```
@@ -644,10 +682,11 @@ res = [s+'|'+s ; s <- tolist(src); !(s ?> '123')]
 ```
 
 ### 13. Multiline expressions: `if`, `for`, math expr.  
-Normally code lines in LP are short enough, but in some cases we need longer expressions, even in control statements.
+Normally code lines in LP are short enough, but in some cases we need longer expressions, even in control statements.  
 The main way to split long line to shorten parts is use brackets.
-For comprehantion expressions it works with its square brackets (see examples).
-For function call, `if`, `for` or math expressions we can use round brackets as usual.
+For comprehantion expressions it works with its square brackets (see examples).  
+For function call, `if`, `for` or math expressions we can use round brackets as usual.  
+Indents in multiline case makes code more readable.
 ```
 # func
 val = foo(a,
@@ -681,7 +720,7 @@ setNativeFunc(context, 'func_name', python_function, ResultType)
 # example:
 setNativeFunc(ctx, 'print', buit_print, TypeNull)
 ```
-Builtin funcs was changed for call functions passed as argument (lambdas, atc) inside python function: added 1-st arg - Context.
+Upd: Builtin funcs was changed for call functions passed as argument (lambdas, atc) inside python function: added 1-st arg - Context.
 ```
 # if builtin func receives function / lambda, 
 # context is needed
@@ -781,7 +820,7 @@ a, b, c = (1, 2, 3)
 a, b, c = [1,2,3]
 ```
 
-### 18. Ternary operator `?:`. 
+### 18. Ternary operator `?:`
 classic ternary oper `condition ? valIfTrue : elseVal`  
 ```
 x = a < b ? 10 : 20
@@ -793,8 +832,8 @@ returns val1 if not null (zero num, empty string, list or tuple); otherwize retu
 x = val1 ?: va2
 ```
 
-### 19. Bool operator val-in `?>` and val-not-in `!?>` operators.  
-
+### 19. Val-in `?>` and val-not-in `!?>` operators.  
+Boolean operators for check value or key in collection.  
 `a ?> vals` : If collection `vals` contains value `a`  
 ```
 # base usage 
@@ -822,7 +861,7 @@ if 5 !?> [1,2,3] ... # True
 if 'c' !?> {'a':1, 'b':2} ...
 ```
 
-### 20. one-line blocks (expr; expr; expr)
+### 20. One-line block (expr; expr; expr)
 Shortened syntax for those who like long lines and hates tall columns :)  
 ```
 a = 1; b = 2; c = 3
@@ -862,38 +901,84 @@ func fHello(s)
 See more examples in `tests/test_format.py`.
 
 ### 22. Import modules.  
+We can use things from another module by using `import` command.  
+Module is a file. Module name is a filename withot extension.  
+So file `test.et` contains module `test`  
+File `lib/util.et` contains module `lib.util`  
+Cases of import:  
+- Import module (file), submodule in folder  
+(over dots: `dir.subdir.file` ).
+- Import all things from module, or named things.
+- Alias for named things.
 
-Cases:  
-- Imports module (file), submodule in folder (over dots: dirname.dirname2.module ).
-- Imports all things from module, or named things.
-- Aliases usage for named things.
-- TODO: auto-import modules from file-tree for CI `run`.
-
+Pure import, just module name
 ```
-# pure import, just module name
-import some_module
-some_module.foo()
-inst = some_module.MyType{a:1}
+import mymodule
+mymodule.foo()
+inst = mymodule.MyType{a:1}
 inst.bar()
+```
+Import all things from module.  
+```
+import mymodule.*
+mymodule.foo(123)
 
-# import all 
-import some_module.*
-some_module.foo(123)
-
-# import names
-import some_module > foo, bar, MyType
+# Note: Syntax can be changed to `module > *`.
+```
+  
+Import names from module.  
+`module > name, name2`
+```
+import mymodule > foo, bar, MyType
 foo(123)
 bar(321)
 mt = MyType{a:1, b:2}
-
-# import aliases
-import some_module > foo f1, bar f2
+```
+Import with aliases.  
+`module > name alias, ..`
+```
+import mymodule > foo f1, bar f2
 f1(123)
 f2(321)
 ```
+### 22.1 Module preload. 
+`import` command looks for modules in the execution root context. So we have to preload modues into context before run code with imports.  
+For `run.py` util we have 2 options how to preload modules.  
+1) Module can be imported by console arg `-i` or `--import`.  
+    Modules will be preloaded into root context and `import` lines will be added to the head of code.  
+```
+$ py -m run -i "module1; module2..." -c "code"
+```
+Example:  
+File to import: `./tests/tdata/st1.et`  
+```
+py -m run 
+    -i "tests.tdata.st1 > Point2, f1" 
+    -c "pp = Point2{x:2, y:3}; p = f1(pp.sum())" -r p
+>> [5, 10, 15]
+```
+
+2) Auto-import modules from file-tree for CI `run`.  
+For case with the the source file (if contains `import`), importing modules will be preloaded before execution of script automatically.  
+Root path is taken from current console position.  
+```
+$ py -m run tests/tmods.et
+test-import1: 12
+test-import2: st=B 17
+```
+Pathroot.  
+We can use custom root path for impoting.  
+Arg for pathroot: `-p` `--pathroot`. Useful for run script from any location.  
+```
+
+py -m run -p "tests" 
+    -i "tdata.st1 > Point2, f1"  
+    -c "pp = Point2{x:2, y:3}; a = pp.sum(); tt = (f1(a))" 
+    -r tt
+```
 
 ### 23. Function as an object. 
-We can use a function not only as a predefined name, but also as a value, place it in collections, take it from an expression, and call it.  
+We can use a function not only as a predefined name for call, but also as a value, place it in collections, take it from an expression, and use.  
 Typical cases:  
 - functions in list
 ```
@@ -957,7 +1042,7 @@ func foo5(f)
 
 res = foo5(y -> y * 3)(33)
 ```
-### 24. `Closures`.  
+### 24. Closures.  
 Lambdas can use things defined in the function where lambda was defined,  
 including another lambdas passed into parent function.
 ```

--- a/tests/tdata/sdata/mod1.et
+++ b/tests/tdata/sdata/mod1.et
@@ -1,0 +1,5 @@
+
+struct St10
+    aa: int
+    bb: int
+

--- a/tests/tdata/sdata/sdata2/mod21.et
+++ b/tests/tdata/sdata/sdata2/mod21.et
@@ -1,0 +1,5 @@
+
+struct St20 
+    name: string
+    num: int
+

--- a/tests/tdata/st1.et
+++ b/tests/tdata/st1.et
@@ -1,0 +1,14 @@
+
+# Module ST1
+
+func f1(x)
+    [x, 2 * x, 3 * x]
+
+struct Point2
+    x: int
+    y: int
+
+func p: Point2 sum()
+    p.x + p.y
+
+# py -m run -i "tests.tdata.st1 > Point2, f1"  -c "pp = Point2{x:2, y:3}; a = pp.sum(); p = (f1(a))" -r p

--- a/tests/tdata/st2.et
+++ b/tests/tdata/st2.et
@@ -1,0 +1,4 @@
+
+struct St2
+    a: int
+    b: string

--- a/tests/tmods.et
+++ b/tests/tmods.et
@@ -1,0 +1,12 @@
+
+import tests.tdata.st1 # Point2{x, y}, f1(x) : []
+import tests.tdata.st2 > St2
+
+p1 = st1.Point2{x:5, y:7}
+
+psum = p1.sum()
+print('test-import1:', psum)
+
+st = St2{a: 10, b: 'st=B'}
+
+print('test-import2:', st.b, st.a + p1.y)

--- a/todo.et
+++ b/todo.et
@@ -59,6 +59,15 @@
             expr1
         2 !- for i <- nlist
             foo(i)
+
+14.2 maybe refactor !- as a start-line operator? with explicit indent for any sub-expressions. Not sure.
+    match x
+        !- 1
+            expr
+        !- 2
+            expr
+
+
 14.2 Looks like multi-if will be more useful:
     if
         a < 5
@@ -103,6 +112,7 @@
     solution `list += [a, b, c]` looks ok
     check and fix cases: list + list, string + string
 
+23. Common lib location for importing (not sure we need it now).  
 
 
 


### PR DESCRIPTION
Ad auto preload of importing modules for `run file`. 
Add import modules for `run -c`. 
Add `-e` for native error output. 
Add `-p` for pathroot. 
Some tests. Readme and notes.