### PR TITLE
Fix generators, plus for lists.

### DIFF
--- a/build.py
+++ b/build.py
@@ -27,27 +27,6 @@ def getArgs():
     return args
 
 
-# def readFile(filename):
-#     '''return file content'''
-#     fpath = filepath(filename)
-#     with open(fpath, 'r') as fr:
-#         return fr.read()
-    
-
-# def buildTree(src):
-#     '''Parse and build executable tree.'''
-#     tlines = splitLexems(src)
-#     clines:list[CLine] = elemStream(tlines)
-    
-#     exp = lex2tree(clines)
-#     return exp
-
-# def buildFile(filename):
-#     '''Read file and build exec tree'''
-#     src = readFile(filename)
-#     return buildTree(src)
-
-
 def tree2bin(expr:Expression):
     '''Serialize exec tree.'''
     # TODO: think about protobufs

--- a/cases/oper.py
+++ b/cases/oper.py
@@ -433,6 +433,9 @@ class CaseListComprehension(SubCase):
         if cs.match(sub):
             _, subs = cs.split(sub)
         exp = ListComprExpr()
+        subs = [s for s in subs if len(s)]
+        # prels('LC.elems = :', elems, show=1) 
+        # prels('ListComr subs=', subs, show=1)
         return exp, subs
 
     def setSub(self, base:Block, subs:Expression|list[Expression])->Expression:

--- a/cases/utils.py
+++ b/cases/utils.py
@@ -62,12 +62,23 @@ def isGetValExpr(elems:list[Elem]):
 def isBrPair(elems:list[Elem], opn, cls):
     return isLex(elems[0], Lt.oper, opn) and isLex(elems[-1], Lt.oper, cls)
 
+def el_text(elems:list[Elem]):
+    return [n.text for n in elems]
 
 def prels(pref, elems:list[Elem], *args, **kwargs):
-    if 'show' in kwargs and kwargs['show']:
-        print(pref, [n.text for n in elems], *args)
+    if not (FullPrint or ('show' in kwargs and kwargs['show'])):
         return
-    dprint(pref, [n.text for n in elems], *args)
+    
+    # list[list[Elem]]
+    if isinstance(elems[0], (list, tuple)):
+        print(pref, end='')
+        for subel in elems:
+            print(el_text(subel), end=' $$ ', sep = ' ')
+        print('')
+        return
+
+    # list[Elem]
+    print(pref, el_text(elems), *args)
 
 
 def elemStr(elems:list[Elem]):

--- a/nodes/oper_nodes.py
+++ b/nodes/oper_nodes.py
@@ -295,6 +295,12 @@ class OpMath(BinOper):
         a.delete(key)
         return val
 
+    def listPlus(self, a:ListVal, b:ListVal):
+        # print('listPlus:', a, b)
+        res = a.copy()
+        res.addMany(b)
+        return res
+
     def strLshift(self, a, b):
         ''' "str pattern " << (vals) '''
         if not isinstance(b, TupleVal):
@@ -311,6 +317,9 @@ class OpMath(BinOper):
         a, b = valFrom(a), valFrom(b)
         dprint('#bin-overs-1', a, b)
         match self.oper:
+            case '+' :
+                if isinstance(a, (ListVal)) and isinstance(b, ListVal):
+                    return (True, self.listPlus(a, b))
             case '-' :
                 if isinstance(a, (ListVal, DictVal)) and isinstance(b, ListVal):
                     return (True, self.collMinus(a, b))

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ Content:
 9. Collection features:
     1. [append operator `nums <- 15`](#91-arrow-appendset-operator--)
     2. [deletion operator `data - [key]`](#92-minus-key---key-delete-operator)
+    3. [plus for lists `[] + []`](#93-list-plus---)
 10. Struct: 
     1. [Definition, constructor, fields](#10-struct)
 11. Struct OOP:
@@ -469,6 +470,18 @@ For dict:
 d2 = {'a':11, 'b':22}
 r2 = d2 - ['a'] # returns 11
 >> {'b': 22}
+```
+
+### 9.3 List plus `[] += []`
+We can use plus and plus-assign operators for two lists.  
+```
+a = [3,4]
+b = [5,6]
+nums = [1,2] + a
+nums += b
+nums += [7,8,9]
+
+>> [1, 2, 3, 4, 5, 6, 7, 8, 9]
 ```
 
 ### 10. Struct.  

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Content:
 12. List features:
     1. [Slice, iteration generator: `[ : ]`, `[ .. ]`](#121-list-features-slice-iteration-generator-tolist)
     1. [Sequence generator `[ ; ; ]`](#122-list-comprehension--sequence-generator)
-13. [Multiline esxpressions](#13-multiline-expressions-if-for-math-expr)
+13. [Multiline expressions](#13-multiline-expressions-if-for-math-expr)
 14. [Builtin/native functions (print, iter,..)](#14-builtin-functions)
 15. [Lambdas and high-order functions `x -> x ** 2`](#15-lambda-functions-and-high-order-functions-right-arrow--)
 16. [Match-statement](#16-match-statement)

--- a/run.py
+++ b/run.py
@@ -13,21 +13,21 @@ run.py filename.etb (execute previously built file)
 # TODO: add iterative call of built code.
 
 
-import argparse
+# import argparse
 from argparse import ArgumentParser
 import lang
 import json
 from pathlib import Path
 
-from lang import *
 import loader
+from lang import *
+from loader import buildTree, readFile
 from base import Val, Var, InterpretErr, EvalErr, XDebug
 from typex import valType
 from vars import ListVal, DictVal, TupleVal
 from context import Context, RootContext
 from nodes.expression import Expression, expSrc
 from nodes.tnodes import Module
-from build import buildTree, readFile
 from eval import rootContext
 
 

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -52,6 +52,24 @@ class TestDev(TestCase):
 
 
 
+    def _test_code(self):
+        ''' '''
+        code = r'''
+        print('res = ', nums)
+        '''
+        code = norm(code[1:])
+
+        tlines = splitLexems(code)
+        clines:CLine = elemStream(tlines)
+        ex = lex2tree(clines)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        ex.do(ctx)
+        # rvar = ctx.get('res')
+        # self.assertEqual(0, rvar.getVal())
+        # rvar = ctx.get('res').get()
+        # self.assertEqual([], rvar.vals())
+
 
     def _test_barr(self):
         ''' '''

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -21,8 +21,6 @@ from nodes.tnodes import Var
 from nodes import setNativeFunc, Function
 from tests.utils import *
 
-import loader as ld
-from loader import *
 
 import pdb
 
@@ -53,63 +51,6 @@ class TestDev(TestCase):
     '''
 
 
-    def test_loader_mod_path(self):
-        ''' '''
-        caseImp = CaseImport()
-        import os as pt
-        
-        
-        data = [
-            {'path': 'abc'.split('.'), 'exp': 'abc.et'},
-            {'path': 'aa.bb.cc'.split('.'), 'exp': 'aa%%bb%%cc.et'.replace('%%', os.sep)},
-            {'path': 'aa_bb.cc'.split('.'), 'exp': 'aa_bb%%cc.et'.replace('%%', os.sep)},
-            {'path': 'aa.bb.cc.dd.ee'.split('.'), 'exp': 'aa%%bb%%cc%%dd%%ee.et'.replace('%%', os.sep)},
-        ]
-        for pp in data:
-            path = caseImp.fileByPath(pp['path'])
-            # print('tt>', path)
-            self.assertEqual(pp['exp'], path)
-
-    def test_loader_preload(self):
-        ''' '''
-        data = [
-            {'path':'sdata%%mod1.et'.replace('%%', os.sep), 'name':'mod1'},
-            {'path':'sdata%%sdata2%%mod21.et'.replace('%%', os.sep), 'name':'mod21'},
-            # '',
-            # '',
-        ]
-        basePath = Path(__file__).with_name('tdata')
-        rCtx = rootContext()
-        for pp in data:
-            modPath = pp['path']
-            # fpath = ld.filePath(modPath)
-            modName = pp['name']
-            mod = modPreload(rCtx, modPath, root=basePath, name=modName)
-            print('tt>>loadMod:', rCtx.loaded[pp['name']].name)
-            self.assertIsInstance(mod, Module)
-            self.assertEqual(modName, mod.name)
-            
-
-    def _test_loader_struct_context(self):
-        ''' '''
-        code = r'''
-        res = 0
-        
-        print('res = ', res)
-        '''
-        code = norm(code[1:])
-
-        tlines = splitLexems(code)
-        clines:CLine = elemStream(tlines)
-        ex = lex2tree(clines)
-        rCtx = rootContext()
-        ctx = rCtx.moduleContext()
-        ex.do(ctx)
-        rvar = ctx.get('res')
-        self.assertEqual(0, rvar.getVal())
-        rvar = ctx.get('res').get()
-        self.assertEqual([], rvar.vals())
-        lang.FullPrint = 0
 
     def _test_barr(self):
         ''' '''
@@ -241,7 +182,7 @@ class TestDev(TestCase):
         ''' thoughts:
             1) [..;..;..] should be a list-generator, not string
             2) [..; s <- "..."] in gen from string we want to get string
-            3) ~[s, s <- "..."] solutution (1) `~` operator as a list-to-string convertor
+            3) ~[s, s <- "..."] solution (1) `~` operator as a list-to-string convertor
             3.1) looks like `join` func can be a good solution
         '''
         code = '''

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -52,6 +52,7 @@ class TestDev(TestCase):
 
 
 
+
     def _test_barr(self):
         ''' '''
         code = r'''
@@ -214,20 +215,6 @@ class TestDev(TestCase):
         src = "Hello strings!"
         res = [ [a ; a <- src]
         # print('src = ', src)
-        print('nums = ', nums)
-        '''
-        code = norm(code[1:])
-        tlines = splitLexems(code)
-        clines:CLine = elemStream(tlines)
-        ex = lex2tree(clines)
-        ctx = rootContext()
-        ex.do(ctx)
-
-    def _test_list_gen_empty_end(self):
-        ''' list generator. [... expr;] empty last sub-case after semicolon'''
-        code = '''
-        nums = [[x ** 2] ; x <- [2..5] ;]
-        nums = [[x ** 2] ; x <- [2..5] ; ]
         print('nums = ', nums)
         '''
         code = norm(code[1:])

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -99,6 +99,24 @@ class TestLists(TestCase):
         rvar = ctx.get('res').get()
         self.assertEqual([1, (2, 3), (4, 5)], rvar.vals())
 
+    def test_list_gen_empty_end(self):
+        ''' list generator. [... expr;] empty last sub-case after semicolon'''
+        code = '''
+        nums1 = [[x ** 2] ; x <- [2..5] ; x > 1; ]
+        nums2 = [[x ** 2 + 1] ; x <- [2..5] ;]
+        res = [nums1, nums2]
+        # print('nums = ', res)
+        '''
+        code = norm(code[1:])
+        tlines = splitLexems(code)
+        clines:CLine = elemStream(tlines)
+        ex = lex2tree(clines)
+        ctx = rootContext()
+        ex.do(ctx)
+        exp = [[[4], [9], [16], [25]], [[5], [10], [17], [26]]]
+        rvar = ctx.get('res').get()
+        self.assertEqual(exp, rvar.vals())
+
     def test_slice_of_generator(self):
         ''' # TODO: nn = [1..10]; nn5 = nn[1:5] '''
         code = r'''

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -23,6 +23,30 @@ class TestLists(TestCase):
 
 
 
+    def test_plus_operator_for_lists(self):
+        ''' '''
+        code = r'''
+        a = [1,2,3]
+        res = a + [4,5]
+        
+        b = [6]
+        res += b
+        
+        res += [7]
+        
+        print('res = ', res)
+        '''
+        code = norm(code[1:])
+
+        tlines = splitLexems(code)
+        clines:CLine = elemStream(tlines)
+        ex = lex2tree(clines)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        ex.do(ctx)
+        rvar = ctx.get('res').get()
+        self.assertEqual([1,2,3,4,5,6,7], rvar.vals())
+
     def test_arrow_append_when_func_call_left(self):
         ''' For left-arrow operator target is result of function call 
         (returns collection).

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -6,20 +6,13 @@ from tests.utils import *
 from lang import Lt, Mk, CLine
 from parser import splitLine, splitLexems, charType, splitOper, elemStream
 from vars import *
-from vals import numLex
 
 from cases.utils import *
-
-from nodes.tnodes import Var
-from nodes import setNativeFunc, Function
 from nodes.structs import *
-
-from context import Context
 from tree import *
 from eval import rootContext, moduleContext
-
 from strformat import *
-
+from loader import *
 
 from tests.utils import *
 
@@ -33,6 +26,39 @@ class TestModule(TestCase):
     # TODO: fix types in imported structs
     
 
+    def test_import_file_by_path(self):
+        ''' '''
+        caseImp = CaseImport()
+        
+        data = [
+            {'path': 'abc'.split('.'), 'exp': 'abc.et'},
+            {'path': 'aa.bb.cc'.split('.'), 'exp': 'aa%%bb%%cc.et'.replace('%%', os.sep)},
+            {'path': 'aa_bb.cc'.split('.'), 'exp': 'aa_bb%%cc.et'.replace('%%', os.sep)},
+            {'path': 'aa.bb.cc.dd.ee'.split('.'), 'exp': 'aa%%bb%%cc%%dd%%ee.et'.replace('%%', os.sep)},
+        ]
+        for pp in data:
+            path = caseImp.fileByPath(pp['path'])
+            # print('tt>', path)
+            self.assertEqual(pp['exp'], path)
+
+    def test_loader_preload(self):
+        ''' '''
+        data = [
+            {'path':'sdata%%mod1.et'.replace('%%', os.sep), 'name':'mod1'},
+            {'path':'sdata%%sdata2%%mod21.et'.replace('%%', os.sep), 'name':'mod21'},
+            # '',
+            # '',
+        ]
+        basePath = Path(__file__).with_name('tdata')
+        rCtx = rootContext()
+        for pp in data:
+            modPath = pp['path']
+            # fpath = ld.filePath(modPath)
+            modName = pp['name']
+            mod = modPreload(rCtx, modPath, root=basePath, name=modName)
+            print('tt>>loadMod:', rCtx.loaded[pp['name']].name)
+            self.assertIsInstance(mod, Module)
+            self.assertEqual(modName, mod.name)
 
     def loadCode(self, code, name=''):
         code = norm(code[1:])

--- a/todo.et
+++ b/todo.et
@@ -108,7 +108,8 @@
         it should have reset() method
         # sugar: val <= src // ?
 
-22. append meany values to list `res <- vals`, like dict has
+22. # DONE by `+=`
+     append many values to list `res <- vals`, like dict has
     solution `list += [a, b, c]` looks ok
     check and fix cases: list + list, string + string
 

--- a/vars.py
+++ b/vars.py
@@ -123,6 +123,11 @@ class ListVal(Collection):
         # print('ListVal.addVal:', val)
         self.elems.append(val)
     
+    def addMany(self, vals:'ListVal'):
+        # not sure, we need whole Var or just internal value?
+        # print('ListVal.addVal:', val)
+        self.elems.extend(vals.elems)
+    
     def setVal(self, key:Val, val:Val):
         i = key.getVal()
         # dprint('ListVar.setVal', i, val, 'Len=', len(self.elems), i < len(self.elems), self.elems)
@@ -147,6 +152,9 @@ class ListVal(Collection):
             raise EvalErr('indexes of List slice are out of range [%d : %d] with len = %d' % (beg, end, len(self.elems)))
         rdata = self.elems[beg: end]
         return ListVal(elems=rdata)
+
+    def copy(self):
+        return ListVal(elems=self.elems[:])
 
     def get(self):
         return  [n.get() for n in self.elems] # debug


### PR DESCRIPTION
Fix generators with redundant `;` before close bracket.
Implement `+` plus and `+=` for lists.