### PR TITLE
Refactor block constructors of collections: brackets without type name.

### DIFF
--- a/cases/collection.py
+++ b/cases/collection.py
@@ -87,7 +87,7 @@ class CaseList(SubCase):
         return exp, subs
 
     def setSub(self, base:Block, subs:Expression|list[Expression])->Expression:
-        dprint('CaseList.setSub: ', base, subs)
+        # dprint('CaseList.setSub: ', base, subs)
         for exp in subs:
             if isinstance(exp, NothingExpr):
                 # empty position after comma
@@ -100,9 +100,10 @@ class CaseList(SubCase):
 class CaseListBlock(SubCase):
     def match(self, elems:list[Elem]) -> bool:
         '''
-        list
-        varName = list
+        []
+        varName = []
         '''
+        return False # deprecated
         if len(elems) != 1:
             return False
         return isLex(elems[0], Lt.word, 'list')
@@ -286,6 +287,7 @@ class CaseDictBlock(SubCase):
         dict
         from varName = dict
         '''
+        return False # deprecated
         # dprint('CaseDictBlock.match')
         if len(elems) != 1:
             return False

--- a/nodes/base_oper.py
+++ b/nodes/base_oper.py
@@ -34,6 +34,10 @@ class BinOper(OperCommand):
         # dprint('BinOper.setArgs', left, right)
         self.left = left
         self.right = right
+    
+    def add(self, expr:Expression):
+        ''' where right is MultilineVal '''
+        self.right.add(expr)
 
 
 class AssignExpr(BinOper):

--- a/nodes/expression.py
+++ b/nodes/expression.py
@@ -30,6 +30,9 @@ class Expression:
     def __str__(self):
         return self.__class__.__name__
 
+    add = None
+
+
 class CommentExpr(Expression):
     ''' for future usage'''
     def __init__(self, text:str):
@@ -268,9 +271,10 @@ class DeclarationExpr(Expression):
         self.typeExpr.do(ctx)
         self.var = self.varExpr.do(ctx)
         self.var.setType(self.typeExpr.get())
-    
+
     def get(self)->Var:
         ''' return '''
+
 
 class DefinitionExpr(Expression):
     ''' base for struct, alias
@@ -338,6 +342,10 @@ class ServPairExpr(Expression):
         # print('ServPairExpr.setArgs', left, right)
         self.left = left
         self.right = right
+
+    def add(self, expr:Expression):
+        ''' where right is MultilineVal '''
+        self.right.add(expr)
 
 
 class VarStrict(Var):

--- a/nodes/iternodes.py
+++ b/nodes/iternodes.py
@@ -7,10 +7,12 @@ Mostly for usage into for-loop or generators.
 from lang import *
 from vars import *
 from vals import *
+
+from nodes.base_oper import BinOper
 from nodes.expression import *
 from nodes.oper_nodes import OpAssign
-from nodes.func_expr import FuncCallExpr
-import nodes.datanodes
+# from nodes.func_expr import FuncCallExpr
+# import nodes.datanodes
 from nodes.datanodes import DictVal, ListVal, TupleVal
 
 
@@ -334,7 +336,7 @@ class Append(Expression):
                     self.target.data[key] = val
 
 
-class LeftArrowExpr(Expression):
+class LeftArrowExpr(BinOper):
     ''' '''
 
     def __init__(self, src = ''):
@@ -350,10 +352,13 @@ class LeftArrowExpr(Expression):
         # print('Arr <- setArgs1', left, right)
         self.leftExpr = left
         self.rightExpr = right
+
+    def add(self, expr:Expression):
+        ''' where right is MultilineVal '''
+        self.rightExpr.add(expr)
     
     # def start(self, ctx:Context):
     #     self.expr.start()
-        
     
     def init(self, ctx:Context):
         ''' get left, right, decide what the case here: iter or append '''

--- a/readme.md
+++ b/readme.md
@@ -31,11 +31,11 @@ Content:
 6. [Dict `{'key':val}`](#6-dict-linear-and-block-constructor)
 7. [For-statement: `for i <- [1..5]`](#7-for-statement---operator)
 8. Functions:`func foo()`  
-    1 [Base info](#8-function-definition-context-of-functions)  
-    2 [Default arguments `func foo(x=1)`](#82-default-value-of-arguments)  
-    3 [Named arguments `n = foo(x=2)`](#83-named-arguments)  
-    4 [Variadik arguments `func foo(args...)`](#84-variadic-arguments)  
-    5 [Overload of functions](#85-function-overload)  
+    1) [Base info](#8-function-definition-context-of-functions)  
+    2) [Default arguments `func foo(x=1)`](#82-default-value-of-arguments)  
+    3) [Named arguments `n = foo(x=2)`](#83-named-arguments)  
+    4) [Variadic arguments `func foo(args...)`](#84-variadic-arguments)  
+    5) [Overload of functions](#85-function-overload)  
 9. Collection features:  
     1. [append operator `nums <- 15`](#91-arrow-appendset-operator--)
     2. [deletion operator `data - [key]`](#92-minus-key---key-delete-operator)
@@ -490,7 +490,7 @@ nums = ['One', 'Two', 'Three']
 
 List, block constructor (for long elements)
 ```python
-names = list
+names = []
     'Anna'
     'Barbi'
     'Cindy'
@@ -516,9 +516,12 @@ print(nums[-2])
 2. Tuples: `(val, val, val)`.  
 
 Tuple. Few values in the parenthesis over comma.  
-Tuple is immutable.
+Tuple is immutable.  
 ```python
 vals = (1, 100, 'More numbers')
+
+# comma means that here is a constr of empty tuple, not just brackets
+val = (,)
 
 # read value by index
 print(vals[2])
@@ -532,13 +535,22 @@ vals = (1, 22, 33,3)
 a, b, c = vals
 ```
 
+Tuple has block contructor too.  
+```python
+data = (,)
+    11
+    'Vasya Pupkin'
+    ['a', 'b', 'c']
+data[1] # >> 'Vasya Pupkin'
+```
+
 ### 6. Dict. Linear and block constructor
 ```python
 # linear constr
 dd = {'a':1, 'b':2}
 
 # block constr
-ddd = dict
+ddd = {}
     'a': 'a a a a a a a a a a a a a a a a a'
     'b': 'b b b b b b b b b b b b b b b b b'
 
@@ -800,7 +812,7 @@ The same about functional objects (like lambdas or function in variable).
 Combinations of different approaches wasn't planned, implemented or tested.  
 
 
-All features: variadic and named args, default vals, overloading (looks like) works for methods too.  
+All features (looks like): variadic and named args, default vals, overloading works for methods too.  
 
 See more about functions in next sections:  
 [14 builtins](#14-builtin-functions), 
@@ -2029,7 +2041,7 @@ ffs[1]('arg-val')
 ```
 - function in dict
 ```golang
-ffd = dict
+ffd = {}
     'f' : foo,
     's' : sum
 

--- a/tests/full_example.et
+++ b/tests/full_example.et
@@ -184,7 +184,7 @@ names = ['Alladin','Bob','Colin','ddd']
 names[3] = 'Dude'
 
 # List, multiline constructor
-lorem = list
+lorem = []
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit," 
     "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." 
     "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris"
@@ -197,7 +197,7 @@ lorem = list
 colors = {'red':'#ff0000', 'green':'#00ff00', 'blue':'#0000ff'}
 
 # Dict, multiline constructor
-weekDays = dict
+weekDays = {}
     1: 'Monday'
     2: 'Tuesday'
     3: 'Wednesday'
@@ -227,7 +227,7 @@ struct Product
     amount:int
 
 struct Book title:string, author:string, pages:int, prod:Product
-books = list
+books = []
     Book{title:'Green  gardens', author:'Bob Stinger', pages:100, prod: Product{price:10., amount:1111}}
     Book{title:'Blue, blue sky', author:'Ani Arabesquin', pages:200, prod: Product{price:20., amount:2222}}
     Book{title:'Silver sword of small town', author:'Arnold Whiteshvartz', pages:300, prod: Product{price:20., amount:3333}}

--- a/tests/multilines.et
+++ b/tests/multilines.et
@@ -33,7 +33,7 @@ back-q
 m-string ''' """
 ```
 
-mlist = list
+mlist = []
     '''
     mstr 1 ' " `
     '''

--- a/tests/parser.et
+++ b/tests/parser.et
@@ -50,7 +50,7 @@ func a:A afunc(x:string, y:string):
 func foo2(arg:int, args:int ...)
     [arg + n; n <- args;]
 
-names = list
+names = []
     'Adam'
     'Bobr'
     'Cyclon'

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -160,46 +160,6 @@ class TestDev(TestCase):
             print('hh>>', hash)
 
 
-    def _test_new_collection_constr(self):
-        ''' constr-like brackets with colon - []:, {}:, (): '''
-        code = r'''
-        res = []
-        
-        varList = []:
-            111,
-            222,
-            333
-        
-        # varDict = {}:
-        #     1:1111
-        #     2:2222
-        #     3:3333
-        
-        # Vd2= {}:
-        #     'a': 'AAAAAAAAAAAAAAAAAAAA'
-        #     'b': 'BBBBBBBBBBBBBBBBBBB'
-        #     'c': 'CCCCCCCCCCCCCCCCCC'
-        
-        # varTuple = ():
-        #     'aaaaa'
-        #     'bbbbb'
-        
-        print(f1(200))
-        # print('res = ', 1)
-        '''
-        code = norm(code[1:])
-
-        tlines = splitLexems(code)
-        clines:CLine = elemStream(tlines)
-        ex = lex2tree(clines)
-        rCtx = rootContext()
-        ctx = rCtx.moduleContext()
-        trydo(ex, ctx)
-        # print('>>', dd.values())
-        # self.assertEqual(0, rvar.getVal())
-        # rvar = ctx.get('res').get()
-        # self.assertEqual([], rvar.vals())
-
 
     def _test_code(self):
         ''' '''

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -1309,7 +1309,7 @@ class TestFunc(TestCase):
         ffs = [x2, x -> 5000 + x]
         
         # lambda in dict
-        ffd = dict
+        ffd = {}
             'f' : ((a) -> a * 11)
             's' : ((a, b) -> a * b)
         

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -432,7 +432,7 @@ class TestLang(TestCase):
         # # multiline
         code = '''
         # create dict var with values in sub-block
-        dd = dict
+        dd = {}
             'red' :'#ff0000'
             'green' :'#00ff00'
             'blue' :'#0000ff'

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -21,6 +21,120 @@ from tree import *
 class TestLists(TestCase):
     ''' Testing lists, iterators, generators, other collections '''
 
+    def test_refactored_block_constr(self):
+        ''' test refactored multiline collections constructors []\\n, {}\\n, (,)\\n '''
+        code = r'''
+        res = []
+        
+        varList = []
+            111
+            222
+        res <- varList
+        
+        varList2 = []
+            'aaaaa'
+            'bbbbb'
+            [11,22,33]
+        res <- varList2
+        
+        varDict = {}
+            1:1111
+            2:2222
+            3:3333
+            'a': 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            'b': {4:444}
+            'cccc': [444,555,666]
+        res <- varDict
+        
+        varTup = (,)
+            100111
+            100222
+            100333
+        res <- varTup
+        
+        rr = ['rr']
+        rr <- []
+            1000
+            1222
+        
+        rr <- {}
+            112: 22222
+            113: 33333
+        
+        res <- rr
+        
+        
+        func fList()
+            []
+                11222
+                11333
+        
+        res <- fList()
+        
+        func fDict()
+            {}
+                11: '1-11'
+                22: '1-22'
+                'a3': [1, 33]
+        
+        lfRes = fList()
+        res <- lfRes
+        
+        dfRes = fDict()
+        res <- dfRes
+        
+        func same(x)
+            x
+        
+        subL = []
+            []
+                2011
+                2022
+                same(3011)
+            {}
+                'c1' : 'armature'
+                'c2': [44,55,66]
+                'c3' : same(4011)
+            (,)
+                'tuple-tuple-123'
+                'tuple-opop-5432'
+            (,)
+        res <- subL
+        
+        subD = {}
+            'x1': []
+                111
+                222
+                same(50333)
+            'x2': {}
+                'a4': 'a4444'
+                'a5': [5,55,555]
+                'a6': same(60111)
+                'a6': [same(60222), same(60333)]
+        res <- subD
+        
+        # print(res)
+        '''
+
+        code = norm(code[1:])
+
+        tlines = splitLexems(code)
+        clines:CLine = elemStream(tlines)
+        ex = lex2tree(clines)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        trydo(ex, ctx)
+        rvar = ctx.get('res').get()
+        exv = [
+            [111, 222], ['aaaaa', 'bbbbb', [11, 22, 33]], 
+            {1: 1111, 2: 2222, 3: 3333, 'a': 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'b': {4: 444}, 'cccc': [444, 555, 666]}, 
+            (100111, 100222, 100333), ['rr', [1000, 1222], {112: 22222, 113: 33333}], 
+            [11222, 11333], [11222, 11333], 
+            {11: '1-11', 22: '1-22', 'a3': [1, 33]}, 
+            [[2011, 2022, 3011], {'c1': 'armature', 'c2': [44, 55, 66], 'c3': 4011}, ('tuple-tuple-123', 'tuple-opop-5432'), ()], 
+            {'x1': [111, 222, 50333], 'x2': {'a4': 'a4444', 'a5': [5, 55, 555], 'a6': [60222, 60333]}}]
+        self.assertEqual(exv, rvar.vals())
+
     def test_code_listgen_plus(self):
         ''' '''
         code = r'''
@@ -786,7 +900,7 @@ class TestLists(TestCase):
         code = '''
         # block-constructor of list
         
-        names = list
+        names = []
             'Anna'
             'Barbi'
             'Cindy'

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -543,7 +543,7 @@ class TestStructs(TestCase):
         code='''
         struct Product price:float, amount:int
         struct Book title:string, author:string, pages:int, prod:Product
-        books = list
+        books = []
             Book{title:'Green  gardens', author:'Bob Stinger', pages:100, prod: Product{price:10., amount:1111}}
             Book{title:'Blue, blue sky', author:'Ani Arabesquin', pages:200, prod: Product{price:20., amount:2222}}
             Book{title:'Silver sword of small town', author:'Arnold Whiteshvartz', pages:300, prod: Product{price:20., amount:3333}}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -517,7 +517,7 @@ class TestTypes(TestCase):
         ff:F = F(7, 'fd7', 'f7')
         gg:G = G(9.01)
         
-        std = dict
+        std = {}
             # []
             'a': [A(2)]
             'b': [B(22, 2.2)]

--- a/todo.et
+++ b/todo.et
@@ -140,32 +140,12 @@ catch crit
     2) executive tree (prepared exec file)
 
 12 Functions: 
-12.1 named args for function: func foo(name:string) # call: foo(name='Abc')
-12.2 other args in `func(a, b, other...) : foo(1, 2, 33, 44, 55, 66, 77) other = [33, 44, 55, 66, 77]
-12.3 #DONE default values of args func foo(x, y=3) :: needed
-12.xx other possible extensions of basic scheme of function:
-    - undeclared args passed by name (like kwargs in python):: thinkable
-    - function / method overload: totally not applicable to strategy of floating number of args like default-val and named-args / No.
     - shortening syntax with obvious-arg in lambda (like scala) `x -> x + 2` => `_ * 2`: not necessary but :: thinkable
     - unused/unnamed var `_` for function args foo(_, x), multiple assignment `for key, _ <- dict`:: thinkable
 
     # type-groups: 
         numeric, bool, string, list, tuple, dict, struct, function, regexp, [set, maybe, tree, ...]
 
-func bar(a, b, [c...])
-    for n <- c /: ..
---
-func foo()
-    1
-func foo(x)
-    x * 2
-func foo(x, y)
-    x + y
-func foo(nums:list)
-    sum(nums)
-func foo(x, y, nums...)
-        [x + y * n ; n <- nums]
-    
 
 13. Interfaces as a some list of method signatures.
 
@@ -361,7 +341,27 @@ Fixes:
     - #DONE data.keys() ; dkeys(data) # dict keys
     - #DONE for item <- ditems(data) ; for item <- data.items()  # key-val pairs from dict
 
+12.1 #DONE named args for function: func foo(name:string) # call: foo(name='Abc')
+12.2 #DONE other args in `func(a, b, other...) : foo(1, 2, 33, 44, 55, 66, 77) other = [33, 44, 55, 66, 77]
+12.3 #DONE default values of args func foo(x, y=3) :: needed
+12.xx other possible extensions of basic scheme of function:
+    # DONE undeclared args passed by name (like kwargs in python):: thinkable
+    # DONE function / method overload: totally not applicable to strategy of floating number of args like default-val and named-args / No.
 
+func bar(a, b, [c...])
+    for n <- c /: ..
+--
+func foo()
+    1
+func foo(x)
+    x * 2
+func foo(x, y)
+    x + y
+func foo(nums:list)
+    sum(nums)
+func foo(x, y, nums...)
+        [x + y * n ; n <- nums]
+    
 3.2. # DONE Type auto-casting. Important for struct constructors, function args
 
 3.2.1 #DONE type auto-conversion in math operators.
@@ -723,6 +723,7 @@ hellos = list
     'Helo desktop!'
 
 #== dict DONE
+# changed to {}
 data = dict
     'a': 1
     'b': 2


### PR DESCRIPTION
Refactor collection block-constructor.
Old option was too ambiguous.
Next looks more readable.
```
val = []
    elem1
    elem2
```