### PR TITLE
Refactor matching of mt-cases (patterm matching case) as part of interpreter optimization.

### DIFF
--- a/cases/collection.py
+++ b/cases/collection.py
@@ -98,7 +98,7 @@ class CaseList(SubCase, SolidCase):
         if lem == 2:
             return True
         if lem == 3:
-            return elems[1].type != Lt.oper or elems[1].test != ','
+            return elems[1].type != Lt.oper or elems[1].text != ','
         
         # r =  isSolidExpr(elems, getLast=True)
         # # print('CaseList.of solid:', r)
@@ -116,8 +116,8 @@ class CaseList(SubCase, SolidCase):
         # print(' $$$$$$$$$$$$$$$$$$$$ CL.comm', cres)
         
         # if [;]
-        if self.csemic.match(inElems):
-            return False
+        # if self.csemic.match(inElems):
+        #     return False
         
         cres = self.cs.match(inElems)
         # return cres
@@ -138,7 +138,7 @@ class CaseList(SubCase, SolidCase):
             return False
         
         # if one elem but complex expression
-        opInd = self.splitter.mainOper(inElems)
+        opInd = self.splitter.mainOper(inElems, lesser = ',')
         if opInd < 0:
             return True
         # print('CL.opSpl', opInd, inElems[opInd].text)

--- a/cases/control.py
+++ b/cases/control.py
@@ -91,6 +91,8 @@ class CaseMatchCase(SubCase):
         base.left = subs[0]
         if len(subs) > 1 and isinstance(subs[1], Expression):
             base.right = subs[1]
+            # print('$#2 ---- >', subs[1].src)
+        return base
 
 
 # class CaseMatchPattern(SubCase):

--- a/cases/control.py
+++ b/cases/control.py
@@ -80,10 +80,10 @@ class CaseMatchCase(SubCase):
         self.splitter = OperSplitter.getInst()
 
     def split(self, elems:list[Elem])-> tuple[Expression, list[list[Elem]]]:
-        arrInd = self.splitter.mainOper(elems)
+        arrInd = self.splitter.mainOper(elems, lesser='/:')
         exp = MatchPtrCase()
         subs = [elems, []]
-        if isLex(elems[arrInd], Lt.oper, '/:'):
+        if arrInd > -1 and isLex(elems[arrInd], Lt.oper, '/:'):
             subs = [elems[:arrInd], elems[arrInd+1:]]
         return exp, subs
 

--- a/cases/matcher.py
+++ b/cases/matcher.py
@@ -8,24 +8,24 @@ from vars import *
 # from vals import isDefConst, elem2val, isLex
 
 from cases.tcases import *
-from cases.control import *
-from cases.oper import *
-from cases.collection import *
-from cases.mt_cases import *
-
-from nodes import *
-from nodes.tnodes import *
+# from cases.control import *
+# from cases.oper import *
+# from cases.collection import *
+# from cases.mt_cases import *
 from cases.sequence import *
-from cases.runar_oper import *
-from nodes.oper_nodes import *
-from nodes.control import *
-from cases.structs import *
-from cases.funcs import *
-from cases.operwords import *
-from cases.modules import *
+# from cases.runar_oper import *
+# from cases.structs import *
+# from cases.funcs import *
+# from cases.operwords import *
+# from cases.modules import *
 
-from parser import *
-from bases.strformat import  *
+# from nodes import *
+# from nodes.tnodes import *
+# from nodes.oper_nodes import *
+# from nodes.control import *
+
+# from parser import *
+# from bases.strformat import  *
 
 
 _1 = r''' 
@@ -132,7 +132,7 @@ class CaseOption(ExpCase):
         self.matcher:CaseLim = matcher
     
     def match(self, info:CMatchInfo)-> bool:
-        # print('CO.match by %s' % (self.matcher.__class__.__name__), self.matcher.match(elems))
+        # print('CO.match by %s' % (self.matcher.__class__.__name__), self.matcher.match(info))
         return self.matcher.match(info)
     
     def isLim(self):
@@ -177,7 +177,7 @@ class CaseOptionPrepared(CaseOption):
         self.found = None
     
     def match(self, info:CMatchInfo)-> bool:
-        # print('CO.match by %s' % (self.matcher.__class__.__name__), self.matcher.match(elems))
+        # print('COP.match by %s' % (self.matcher.__class__.__name__), self.matcher.match(info))
         self.found = None
         mres = self.matcher.match(info)
         if isinstance(mres, tuple):

--- a/cases/mt_cases.py
+++ b/cases/mt_cases.py
@@ -13,6 +13,7 @@ from cases.oper import CaseBrackets, CaseBinOper, CaseVar
 from cases.collection import *
 from cases.structs import *
 from cases.operwords import CaseRegexp
+from cases.matcher import *
 
 
 '''
@@ -87,22 +88,21 @@ class MTVar(MTCase,CaseVar):
 
 
 class MTObjMember(MTCase,CaseDotName):
-    ''' MyEnum.name '''    
+    ''' Pattern should match value from enum.field 
+        or other const/static value field-like (such structures not implemented yet).
+        We can interpret it as a type of const values.
+        expl:
+        Colors.red '''
     
-    
-    def match(self, elems:list[Elem]) -> bool:
+    def match(self, elems:list[Elem], n=0) -> bool:
         ''' '''
         if len(elems) != 3:
             return False
         return super().match(elems)
-        # ln = len(elems)
-        # if ln < 3:
-        #     return False
-        # return isField(elems)
     
     def expr(self, elems:list[Elem])-> Expression:
         ''' Value from context by var name'''
-
+        # print('$.$', elemStr(elems))
         ename = elems[2].text
         objExpr = VarExpr(Var(elems[0].text, TypeAny()))
         member = VarExpr(Var(ename, TypeAny()))
@@ -113,11 +113,12 @@ class MTObjMember(MTCase,CaseDotName):
         return ptt
 
 
-_base_types = "int,float,bool,string,list,tuple,dict,struct,function".split(',')
+# _base_types = "int,float,bool,string,list,tuple,dict,struct,function".split(',')
 
 class MTDuaColon(MTCase):
     ''' :: type  '''
     def match(self, elems:list[Elem])-> bool:
+        # print('$10', elemStr(elems), len(elems) == 2 and isLex(elems[0], Lt.oper, '::') and elems[1].type == Lt.word)
         return len(elems) == 2 and isLex(elems[0], Lt.oper, '::') and elems[1].type == Lt.word
     
     def expr(self, elems:list[Elem])-> tuple[Expression, Expression]:
@@ -138,7 +139,7 @@ class MTTypedVal(MTCase):
         # super().__init__()
         # self.typeOper = IsTypeExpr()
     
-    def match(self, elems:list[Elem])-> bool:
+    def match(self, elems:list[Elem], n=0)-> bool:
         
         if len(elems) != 3:
             # no combo types
@@ -182,12 +183,13 @@ class MTMultiTyped(MTCase):
                 break
         return operInd
 
-    def match(self, elems:list[Elem])-> bool:
-        # print('MTMultiTyped.match', elemStr(elems))
+    def match(self, elems:list[Elem], operInd=None)-> bool:
+        # print('MTMultiTyped.match', elemStr(elems), '<%s>'%operInd)
         if len(elems) < 2:
             return False
         # if isLex(elems[0], Lt.oper, '::')
-        operInd = self.findColons(elems)
+        if operInd is None:
+            operInd = self.findColons(elems)
         if operInd < 0:
             return False
         
@@ -214,7 +216,7 @@ class MTMultiTyped(MTCase):
             elif i % 2 == 1 and not isLex(n, Lt.oper, '|'):
                 # print('MT2', i, elemStr(typeElems), n.text)
                 return False
-        # print('Ok')
+        # print('MTMultiTyped.match', 'Ok')
         return True
 
     def splitTypes(self, elems):
@@ -248,8 +250,8 @@ class MTMultiTyped(MTCase):
         # print()
         operInd = self.findColons(elems)
         typeElems = elems[operInd+1:]
-        # print('$10>>', elemStr(typeElems))
         typeCase = self.splitTypes(typeElems)
+        # print('$10>>', operInd, elemStr(typeElems))
         if not typeCase:
             raise EvalErr("Error during split of type-expr elems in MTTyped")
         # if no var `:: type`
@@ -309,6 +311,33 @@ class MTEQMark(SubElem):
         return MCQMark(src='?')
 
 
+class MTParenth(MTCase):
+    ''' (expr)
+        (1|2)
+        (::int|float) | (A{} | {*})
+        except tuple, empty () also is a tuple
+    '''
+
+    def match(self, elems:list[Elem], ind=None)-> bool:
+        if not (len(elems) > 2 and elems[0].text == '(' and elems[-1].text == ')'):
+            return False
+        ok = True
+        if ind is None:
+            ok, ind = isSolidExpr(elems, getLast=True)
+        if not ok or ind !=0:
+            return False
+        return True
+        # return len(elems) > 2 and elems[0].text == '(' and elems[-1].text == ')'
+
+    def expr(self, elems:list[Elem])-> tuple[Expression, Expression]:
+        ''' return base expression, Sub(elems) '''
+        sub = elems[1: -1]
+        scase = findCase(sub)
+        subExp = scase.expr(sub)
+        # print('mt(...).expr:', elemStr(elems), subExp)
+        return subExp
+
+
 class MTContr(MTCase):
     ''' pattern-container:
     collections, structs,etc'''
@@ -326,7 +355,7 @@ class MTComplex(MTCase):
         ptt | ptt
         ptt :? ptt
     '''
-    _priors = '( ) [ ] { } , | , : ,  `1`, :? '
+    _priors = '( ) [ ] { } , | , ::, : ,  `1`, :? '
 
 
 class MTMultiCase(MTComplex):
@@ -339,19 +368,20 @@ class MTMultiCase(MTComplex):
         self.spl = OperSplitter.getInst(MTComplex._priors)
         self.ps = CaseSeq('|')
 
-    def match(self, elems:list[Elem]) -> bool:
+    def match(self, elems:list[Elem], opInd=None) -> bool:
         # priors = '( ) [ ] { } , | , : ,  `1`, :? '
-        
-        opInd = self.spl.mainOper(elems)
-        
+        tt = opInd
+        if opInd is None:
+            opInd = self.spl.mainOper(elems)
+        # print('?', tt, opInd, elems[opInd].text)
         # print('MTMultiCase.match:', opInd, elems[opInd].text)
         return opInd > 0 and isLex(elems[opInd], Lt.oper, '|')
 
     def expr(self, elems:list[Elem])-> tuple[Expression, Expression]:
         subs = elems
         # print('MTMultiCase.expr:', self.__class__.__name__, '', subs)
-        if self.ps.match(elems):
-            _, subs = self.ps.split(elems)
+        # if self.ps.match(elems):
+        _, subs = self.ps.split(elems)
         mcase = MCMultiCase(src=elems)
         for sub in subs:
             scase = findCase(sub)
@@ -366,19 +396,22 @@ class MTPtGuard(MTComplex, SubCase):
     def __init__(self):
         super().__init__()
         self.spl = OperSplitter.getInst(MTComplex._priors)
-        
+        self.lastId = None
     
-    def match(self, elems:list[Elem]) -> bool:
+    def match(self, elems:list[Elem], opInd=None) -> bool:
         # priors = '( ) [ ] { } , | , : ,  `1`, :? '
-        opInd = self.spl.mainOper(elems)
-        
+        self.lastId = None
+        if opInd is None:
+            opInd = self.spl.mainOper(elems)
+        self.lastId = opInd
         # print('MTPtGuard.match:', opInd, elems[opInd].text)
         return opInd > 0 and isLex(elems[opInd], Lt.oper, ':?')
 
     def split(self, elems:list[Elem])-> tuple[Expression, list[Elem]]:
         # priors = '( ) [ ] { } , | , : ,  `1`, :? '
         # spl = OperSplitter(MTComplex._priors)
-        opInd = self.spl.mainOper(elems)
+        # opInd = self.spl.mainOper(elems)
+        opInd = self.lastId
         left = elems[:opInd]
         patCase = findCase(left)
         pattr = patCase.expr(left)
@@ -404,6 +437,7 @@ class CommaSeparatedSequence(MTContr):
         priors = '( ) [ ] { } , | , : ,  `1` '
         self.spl = OperSplitter.getInst(priors)
         self.cs = CaseCommas()
+        self.noSep = True  # separator is not necessary
 
     def matchEdges(self, elems:list[Elem]):
         pass
@@ -413,15 +447,26 @@ class CommaSeparatedSequence(MTContr):
         # prels('CommaSeparatedSequence', elems, show=1)
         if lem < 2:
             return False
+        ok, ind = isSolidExpr(elems, getLast=True)
+        # print(' @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ ', elemStr(elems), ok, ind)
+        if not ok or ind != 0:
+            return False
         if not self.matchEdges(elems):
             return False
         if len(elems) == 2:
             return True
-        opInd = self.spl.mainOper(elems)
-        # print('1>>>>>>>>>>>>', opInd,  elems[opInd].text)
-        if opInd != 0:
-            return False
+        
         subElems = elems[1:-1]
+        csOk = self.cs.match(subElems)
+        if csOk:
+            return True
+        # next - if 1 sub elem only [1], {22:222}, (expr)
+        return self.noSep
+        
+        # opInd = self.spl.mainOper(elems)
+        # # print('1>>>>>>>>>>>>', opInd,  elems[opInd].text)
+        # if opInd != 0:
+        #     return False
         opInd = self.spl.mainOper(subElems)
         nosub = ';:'
         if isLex(elems[0], Lt.oper, '{'):
@@ -429,9 +474,11 @@ class CommaSeparatedSequence(MTContr):
             nosub = ';'
         # print('2>>>>>>>>', opInd,  subElems[opInd].text)
         obrs = '([{'
-        return opInd == -1 or (
+        brCond = opInd == -1 or (
             opInd == 0 and subElems[opInd].text in obrs ) or (
             opInd > 0 and subElems[opInd].text not in nosub)
+        
+        
 
     def split(self, elems:list[Elem]):
         sub = elems[1:-1]
@@ -484,9 +531,15 @@ class MTTuple(CommaSeparatedSequence):
     ''' (), (1,), (1,2)
         (_), (1,_),
     '''
+    
+    def __init__(self):
+        super().__init__()
+        self.noSep = False
 
     def matchEdges(self, elems:list[Elem]):
-        return (isLex(elems[0], Lt.oper, '(') and isLex(elems[-1], Lt.oper, ')'))
+        if not (isLex(elems[0], Lt.oper, '(') and isLex(elems[-1], Lt.oper, ')')):
+            return False
+        return True
 
     def expr(self, elems:list[Elem])-> tuple[Expression, list[list[Elem]]]:
         subPtts = self.split(elems)
@@ -564,13 +617,13 @@ class MTDict(CommaSeparatedSequence):
 
 
 class MTStruct(MTContr):
-    ''' '''
+    ''' Name{} , _{} , N{field:val} '''
     
     def __init__(self):
         self.struCase = CaseStructConstr()
     
-    def match(self, elems:list[Elem]) -> bool:
-        return (elems[0].type == Lt.word) and self.struCase.match(elems)
+    def match(self, elems:list[Elem], ind=None) -> bool:
+        return (elems[0].type == Lt.word) and self.struCase.match(elems, ind)
 
     def expr(self, elems:list[Elem])-> tuple[Expression, list[list[Elem]]]:
 
@@ -603,16 +656,43 @@ class MTFail(MTCase):
     ''' case of incorrect pattern-syntax '''
 
     def expr(self, elems:list[Elem]):
-        raise InterpretErr("Incorrect pattern-matching sequence")
+        raise InterpretErr("Incorrect pattern-matching sequence %s" % elemStr(elems))
 
 
 pMListInnerCases:list[MTCase] = [
-    MTMultiCase(), MTTypedVal(), MTDuaColon(), MTMultiTyped(),
+    MTMultiCase(), MTDuaColon(), MTTypedVal(),  MTMultiTyped(),
     MTVal(), MTE_(), MTVar(), MTString(), MTRegexp(), MTObjMember(),
     MTEStar(),  MTEQMark(), MTColPair(),
-    MTList(), MTTuple(), MTDict(), MTStruct(), 
+    MTList(), MTTuple(), MTParenth(), MTDict(), MTStruct(), 
 ]
 
+
+def innerMatcher():
+    ''' case-tree of match-case cases. '''
+    
+    # TODO: MT-cases in CaseOptionPrepared should be fixed to take 3 args
+    
+    wordLim = CaseOption(CaseWord(), [MTVal(), MTE_(), MTVar(), MTEStar(),  MTEQMark(), ])
+    brkLim = CaseOption(CaseGenBrackets(), [MTList(), MTTuple(), MTParenth(), MTDict(),])
+    strLim = CaseOption(CaseStr(), [MTString(), MTRegexp(),])
+    solidRight = CaseOptionPrepared(CaseSolidLeft(), [MTStruct(), MTObjMember(),])
+
+    solidLim = CaseOption(CaseSolid(), [wordLim, strLim, solidRight, brkLim])
+    
+    
+    operLim = CaseOptionPrepared(CaseOperLim(), [MTTypedVal(), MTMultiCase(), MTMultiTyped(), MTColPair(),])
+    
+    nonSolLim = CaseOption(NonSolid(), [MTDuaColon(), operLim, MTMultiTyped(),])
+
+    fullMatcher = CaseMatchcher([solidLim, nonSolLim])
+    return fullMatcher
+
+
+_innMatcher = innerMatcher()
+
+def New_findCase(elems:list[Elem])->MTCase:
+    info = CMatchInfo(elems)
+    return _innMatcher.find(info)
 
 def findCase(elems:list[Elem])->MTCase:
     # print('finCase', elems)

--- a/cases/mt_cases.py
+++ b/cases/mt_cases.py
@@ -138,13 +138,17 @@ class MTTypedVal(MTCase):
     # def __init__(self):
         # super().__init__()
         # self.typeOper = IsTypeExpr()
+        
+    def __init__(self):
+        super().__init__()
+        self.validLexTypes = [Lt.word, Lt.num]
     
     def match(self, elems:list[Elem], n=0)-> bool:
         
         if len(elems) != 3:
             # no combo types
             return False
-        if elems[0].type not in [Lt.word, Lt.num]:
+        if elems[0].type not in self.validLexTypes:
             return False
         if not isLex(elems[1], Lt.oper, '::'):
             return False
@@ -153,12 +157,12 @@ class MTTypedVal(MTCase):
     def expr(self, elems:list[Elem])-> tuple[Expression, Expression]:
         ''' return base expression, Sub(elems) '''
         tname = elems[2].text
-        typeExpr = VarExpr(Var(tname, TypeAny()))
         lelem = elems[:1]
         leftCase = findCase(lelem)
         if not leftCase:
             raise EvalErr("No correct left for MTTyped")
         left = leftCase.expr(lelem)
+        typeExpr = VarExpr(Var(tname, TypeAny()))
         return MCTypedElem(left, typeExpr, src=elems)
 
 
@@ -174,6 +178,8 @@ class MTMultiTyped(MTCase):
     def __init__(self):
         super().__init__()
         self.splitter = OperSplitter.getInst()
+        self.splitCases = [CaseBrackets(), CaseBinOper(), CaseVar()]
+        self.lastInd = None
     
     def findColons(self, elems):
         operInd = -1
@@ -185,12 +191,15 @@ class MTMultiTyped(MTCase):
 
     def match(self, elems:list[Elem], operInd=None)-> bool:
         # print('MTMultiTyped.match', elemStr(elems), '<%s>'%operInd)
+        self.lastInd = None
         if len(elems) < 2:
             return False
         # if isLex(elems[0], Lt.oper, '::')
         if operInd is None:
             operInd = self.findColons(elems)
         if operInd < 0:
+            return False
+        if not isLex(elems[operInd], Lt.oper, '::'):
             return False
         
         # check left if has: xx :: ...
@@ -200,47 +209,46 @@ class MTMultiTyped(MTCase):
         # print('$MT-1', elemStr(typeElems))
         # has brackets (A | B)
         if isLex(elems[operInd+1], Lt.oper, '(') and isLex(elems[-1], Lt.oper, ')'):
-            # print('$2', elemStr(typeElems))
-            ok, _ = isSolidExpr(elems[operInd+1:], skipKeywords=True)
+            ok, _ = isSolidExpr(typeElems, skipKeywords=True)
             if ok:
                 typeElems = typeElems[1:-1]
-                # print('$3', elemStr(typeElems))
         # A | B | C
         elen = len(typeElems)
         for i in range(elen):
             n = typeElems[i]
-            # print('6>>', n.text)
             if i % 2 == 0 and n.type != Lt.word:
-                # print('MT1', i, elemStr(typeElems), n.text)
                 return False
             elif i % 2 == 1 and not isLex(n, Lt.oper, '|'):
-                # print('MT2', i, elemStr(typeElems), n.text)
                 return False
-        # print('MTMultiTyped.match', 'Ok')
+        
+        # print('$1', elemStr(elems))
+        self.lastInd = operInd
         return True
 
     def splitTypes(self, elems):
+        # TODO: think about simplifying of types split. Not sure we need nested subtypes
+        # just uncover brackets, split by `|`
+        
         # print('MT splitTypes', elemStr(elems))
-        cases = [CaseBrackets(), CaseBinOper(), CaseVar()]
+        
         subs = elems
-        mid = self.splitter.mainOper(elems)
-        for cs in cases:
-            if cs.match(subs):
-                if cs.sub():
-                    rexp, rsubs = cs.split(subs)
-                    # print('$1>>', rexp, rsubs)
-                    # subs = rsubs
-                    if rsubs:
-                        inExps = []
-                        for rs in rsubs:
-                            sexp = self.splitTypes(rs)
-                            inExps.append(sexp)
-                        # print('$2>>', rexp, inExps)
-                        rexp = cs.setSub(rexp, inExps)
-                    return rexp
-                    # exp = rexp
-                else:
-                    return cs.expr(subs)
+        for cs in self.splitCases:
+            if not cs.match(subs):
+                continue
+            if not cs.sub():
+                return cs.expr(subs)
+            
+            rexp, rsubs = cs.split(subs)
+            # print('$1>>', rexp, rsubs)
+            # subs = rsubs
+            if rsubs:
+                inExps = []
+                for rs in rsubs:
+                    sexp = self.splitTypes(rs)
+                    inExps.append(sexp)
+                # print('$2>>', rexp, inExps)
+                rexp = cs.setSub(rexp, inExps)
+            return rexp
         raise EvalErr("Incorrect pattern of type, multitype MT-pattern.")
 
     # def split(self, elems:list[Elem])-> tuple[Expression, list[Elem]]:
@@ -248,14 +256,15 @@ class MTMultiTyped(MTCase):
         ''' return base expression, Sub(elems) '''
         # tname = elems[2].text
         # print()
-        operInd = self.findColons(elems)
-        typeElems = elems[operInd+1:]
+        # operInd = self.findColons(elems)
+        typeElems = elems[self.lastInd+1:]
+        
         typeCase = self.splitTypes(typeElems)
         # print('$10>>', operInd, elemStr(typeElems))
         if not typeCase:
             raise EvalErr("Error during split of type-expr elems in MTTyped")
         # if no var `:: type`
-        if operInd == 0:
+        if self.lastInd == 0:
             return MCType(typeCase, src=elems)
         # next for typed Var only
         lelem = elems[:1]
@@ -355,7 +364,7 @@ class MTComplex(MTCase):
         ptt | ptt
         ptt :? ptt
     '''
-    _priors = '( ) [ ] { } , | , ::, : ,  `1`, :? '
+    _priors = '( ) [ ] { } , | , :: , : ,  `1`, :? '
 
 
 class MTMultiCase(MTComplex):
@@ -369,18 +378,14 @@ class MTMultiCase(MTComplex):
         self.ps = CaseSeq('|')
 
     def match(self, elems:list[Elem], opInd=None) -> bool:
-        # priors = '( ) [ ] { } , | , : ,  `1`, :? '
-        tt = opInd
+        # check by operators priority, because of: 
+        # :: A | B
         if opInd is None:
-            opInd = self.spl.mainOper(elems)
-        # print('?', tt, opInd, elems[opInd].text)
-        # print('MTMultiCase.match:', opInd, elems[opInd].text)
+            opInd = self.spl.mainOper(elems, lesser='|')
         return opInd > 0 and isLex(elems[opInd], Lt.oper, '|')
 
     def expr(self, elems:list[Elem])-> tuple[Expression, Expression]:
         subs = elems
-        # print('MTMultiCase.expr:', self.__class__.__name__, '', subs)
-        # if self.ps.match(elems):
         _, subs = self.ps.split(elems)
         mcase = MCMultiCase(src=elems)
         for sub in subs:
@@ -397,12 +402,13 @@ class MTPtGuard(MTComplex, SubCase):
         super().__init__()
         self.spl = OperSplitter.getInst(MTComplex._priors)
         self.lastId = None
+        self.ifpref = [Elem(Lt.word, 'if')]
     
     def match(self, elems:list[Elem], opInd=None) -> bool:
         # priors = '( ) [ ] { } , | , : ,  `1`, :? '
         self.lastId = None
         if opInd is None:
-            opInd = self.spl.mainOper(elems)
+            opInd = self.spl.mainOper(elems, ':?')
         self.lastId = opInd
         # print('MTPtGuard.match:', opInd, elems[opInd].text)
         return opInd > 0 and isLex(elems[opInd], Lt.oper, ':?')
@@ -415,7 +421,7 @@ class MTPtGuard(MTComplex, SubCase):
         left = elems[:opInd]
         patCase = findCase(left)
         pattr = patCase.expr(left)
-        right = [Elem(Lt.word, 'if')] + elems[opInd+1:]
+        right = self.ifpref + elems[opInd+1:]
         expr = MCPtGuard()
         expr.pattern = pattr
         return expr, right
@@ -467,16 +473,17 @@ class CommaSeparatedSequence(MTContr):
         # # print('1>>>>>>>>>>>>', opInd,  elems[opInd].text)
         # if opInd != 0:
         #     return False
-        opInd = self.spl.mainOper(subElems)
-        nosub = ';:'
-        if isLex(elems[0], Lt.oper, '{'):
-            # {a:b}
-            nosub = ';'
-        # print('2>>>>>>>>', opInd,  subElems[opInd].text)
-        obrs = '([{'
-        brCond = opInd == -1 or (
-            opInd == 0 and subElems[opInd].text in obrs ) or (
-            opInd > 0 and subElems[opInd].text not in nosub)
+        
+        # opInd = self.spl.mainOper(subElems)
+        # nosub = ';:'
+        # if isLex(elems[0], Lt.oper, '{'):
+        #     # {a:b}
+        #     nosub = ';'
+        # # print('2>>>>>>>>', opInd,  subElems[opInd].text)
+        # obrs = '([{'
+        # brCond = opInd == -1 or (
+        #     opInd == 0 and subElems[opInd].text in obrs ) or (
+        #     opInd > 0 and subElems[opInd].text not in nosub)
         
         
 
@@ -553,12 +560,20 @@ class MTColPair(MTContr, CaseColon):
     ''' pair with colon
         * : * 
     '''
-    def match(self, elems:list[Elem]) -> bool:
+    
+    def __init__(self):
+        super().__init__()
+        self.ccl = CaseColon()
+    
+    def match(self, elems:list[Elem], ind=None) -> bool:
         # print('MTColPair.match')
-        return super(CaseColon,self).match(elems)
+        if ind is not None:
+            return len(elems) > 2 and isLex(elems[ind], Lt.oper, ':')
+        # return super(CaseColon,self).match(elems)
+        return self.ccl.match(elems)
 
     def split(self, elems:list[Elem]):
-        _, parts = super(CaseColon,self).split(elems)
+        _, parts = self.ccl.split(elems)
         if len(parts) != 2:
             raise InterpretErr("Bad count of pair parts in MTColPair")
         # print('MTColPair.expr', parts)
@@ -626,7 +641,6 @@ class MTStruct(MTContr):
         return (elems[0].type == Lt.word) and self.struCase.match(elems, ind)
 
     def expr(self, elems:list[Elem])-> tuple[Expression, list[list[Elem]]]:
-
         constr, subs = self.struCase.split(elems)
         stype = elems[0].text
         # print('MTStruct', stype, subs)
@@ -659,12 +673,12 @@ class MTFail(MTCase):
         raise InterpretErr("Incorrect pattern-matching sequence %s" % elemStr(elems))
 
 
-pMListInnerCases:list[MTCase] = [
-    MTMultiCase(), MTDuaColon(), MTTypedVal(),  MTMultiTyped(),
-    MTVal(), MTE_(), MTVar(), MTString(), MTRegexp(), MTObjMember(),
-    MTEStar(),  MTEQMark(), MTColPair(),
-    MTList(), MTTuple(), MTParenth(), MTDict(), MTStruct(), 
-]
+# pMListInnerCases:list[MTCase] = [
+#     MTMultiCase(), MTDuaColon(), MTTypedVal(),  MTMultiTyped(),
+#     MTVal(), MTE_(), MTVar(), MTString(), MTRegexp(), MTObjMember(),
+#     MTEStar(),  MTEQMark(), MTColPair(),
+#     MTList(), MTTuple(), MTParenth(), MTDict(), MTStruct(), 
+# ]
 
 
 def innerMatcher():
@@ -672,36 +686,36 @@ def innerMatcher():
     
     # TODO: MT-cases in CaseOptionPrepared should be fixed to take 3 args
     
-    wordLim = CaseOption(CaseWord(), [MTVal(), MTE_(), MTVar(), MTEStar(),  MTEQMark(), ])
+    wordLim = CaseOption(CaseWord(), [MTVal(), MTE_(), MTVar(), ])
     brkLim = CaseOption(CaseGenBrackets(), [MTList(), MTTuple(), MTParenth(), MTDict(),])
     strLim = CaseOption(CaseStr(), [MTString(), MTRegexp(),])
     solidRight = CaseOptionPrepared(CaseSolidLeft(), [MTStruct(), MTObjMember(),])
 
     solidLim = CaseOption(CaseSolid(), [wordLim, strLim, solidRight, brkLim])
     
-    
+    wld = CaseOption(CaseAny(), [MTEStar(),  MTEQMark(), MTFail()])
     operLim = CaseOptionPrepared(CaseOperLim(), [MTTypedVal(), MTMultiCase(), MTMultiTyped(), MTColPair(),])
     
-    nonSolLim = CaseOption(NonSolid(), [MTDuaColon(), operLim, MTMultiTyped(),])
+    nonSolLim = CaseOption(NonSolid(), [MTDuaColon(), operLim, MTMultiTyped(), wld,])
 
-    fullMatcher = CaseMatchcher([solidLim, nonSolLim])
+    fullMatcher = CaseMatchcher([ solidLim, nonSolLim])
     return fullMatcher
 
 
 _innMatcher = innerMatcher()
 
-def New_findCase(elems:list[Elem])->MTCase:
+def findCase(elems:list[Elem])->MTCase:
     info = CMatchInfo(elems)
     return _innMatcher.find(info)
 
-def findCase(elems:list[Elem])->MTCase:
-    # print('finCase', elems)
-    # prels('findCase1:', elems, show=1)
-    for cs in pMListInnerCases:
-        if cs.match(elems):
-            # print('finCase >>> ', cs.__class__.__name__)
-            return cs
-    return MTFail()
+# def old_findCase(elems:list[Elem])->MTCase:
+#     # print('finCase', elems)
+#     # prels('findCase1:', elems, show=1)
+#     for cs in pMListInnerCases:
+#         if cs.match(elems):
+#             # print('finCase >>> ', cs.__class__.__name__)
+#             return cs
+#     return MTFail()
 
 def subPatterns(subs:list[list[Elem]])->list[MTCase]:
     if len(subs) == 0:

--- a/cases/oper.py
+++ b/cases/oper.py
@@ -109,7 +109,7 @@ class CaseBinOper(SubCase):
         if ind < 0:
             if self.splitter is None:
                 self.splitter = OperSplitter.getInst()
-            main = self.splitter.mainOper(elems)
+            main = self.splitter.mainOper(elems, lesser='**')
         res =  main > 0 and elems[main].text not in _noOpers and isLex(elems[main], Lt.oper, self.opers)
         self.lastM = main if res else -1
         return res
@@ -446,16 +446,19 @@ class CaseInlineSub(SubCase):
     def __init__(self):
         super().__init__()
         self.spl = OperSplitter.getInst()
+        self.lastId = None
     
     def match(self, elems:list[Elem]) -> bool:
         # print('Case /: >>')
+        self.lastId = None
         if len(elems) < 3:
             return False
         
         if not isLex(elems[0], Lt.word, _inline_contr_keyws):
             return False
 
-        main = self.spl.mainOper(elems)
+        main = self.spl.mainOper(elems, lesser='/:')
+        self.lastId = main
         return elems[main].text == '/:'
         
         # return isLex(elems[main], Lt.oper, '/:')
@@ -463,7 +466,8 @@ class CaseInlineSub(SubCase):
     def split(self, elems:list[Elem])-> tuple[Expression, list[list[Elem]]]:
         ''' '''
         # dprint('CaseInlineSub split', elems)
-        idx = self.spl.mainOper(elems)
+        # idx = self.spl.mainOper(elems)
+        idx = self.lastId
         ctrl = elems[:idx]
         sub = elems[idx+1:]
         # print('', elemStr(ctrl), '<<%s>>' % elems[idx].text, elemStr(sub))

--- a/cases/structs.py
+++ b/cases/structs.py
@@ -104,7 +104,7 @@ class CaseStructConstr(SubCase, SolidCase):
         right part: 
             TypeName {field: val, field: val}
     '''
-    def match(self, elems:list[Elem], ind=-1) -> bool:
+    def match(self, elems:list[Elem], ind=None) -> bool:
         '''
         TypeName {dict-like args}
         module.Typename{args}
@@ -120,7 +120,9 @@ class CaseStructConstr(SubCase, SolidCase):
         dc = CaseDictLine()
         # get curvy brackets part
         # be sure that case already checked as Solid expr
-        ok, pos = isSolidExpr(elems, getLast=True)
+        ok, pos = True, ind
+        if ind is None:
+            ok, pos = isSolidExpr(elems, getLast=True)
         # print('Str.Match', r)
         # if not isinstance(r, tuple):
         #     return False

--- a/cases/structs.py
+++ b/cases/structs.py
@@ -104,6 +104,12 @@ class CaseStructConstr(SubCase, SolidCase):
         right part: 
             TypeName {field: val, field: val}
     '''
+    
+    def __init__(self):
+        super().__init__()
+        self.dc = CaseDictLine()
+        self.cc = CaseCommas()
+    
     def match(self, elems:list[Elem], ind=None) -> bool:
         '''
         TypeName {dict-like args}
@@ -117,7 +123,7 @@ class CaseStructConstr(SubCase, SolidCase):
             return False
         if len(elems) < 2:
             return False
-        dc = CaseDictLine()
+        # dc = CaseDictLine()
         # get curvy brackets part
         # be sure that case already checked as Solid expr
         ok, pos = True, ind
@@ -130,17 +136,17 @@ class CaseStructConstr(SubCase, SolidCase):
         # print('lastFound:', ok, pos, 'lenEl:%d' % len(elems), elems[pos].text)
         if not ok or pos > len(elems)-2 or pos < 1 or not isLex(elems[pos], Lt.oper, '{') : 
             return False
-        return dc.match(elems[pos:])
+        return self.dc.match(elems[pos:])
     
     def split(self, elems:list[Elem])-> tuple[Expression, list[list[Elem]]]:
         _, pos = isSolidExpr(elems, getLast=True, skipKeywords=True)
         typePart = elems[:pos]
         argPart = elems[pos:]
         argSub = argPart[1:-1]
-        cs = CaseCommas()
+        # cs = CaseCommas()
         subs = [argSub]
-        if cs.match(argSub):
-            _, subs = cs.split(argSub)
+        if len(argSub) > 3 and self.cc.match(argSub):
+            _, subs = self.cc.split(argSub)
         return StructConstr(), [typePart] + subs
 
     def setSub(self, base:StructConstr, subs:Expression|list[Expression])->Expression:

--- a/cases/tcases.py
+++ b/cases/tcases.py
@@ -363,7 +363,7 @@ class CaseSeq(SubCase):
         self.opens = self.brs.keys()
         self.closs = self.brs.values()
 
-    def match(self, elems:list[Elem], ind=-1) -> bool:
+    def match(self, elems:list[Elem], ind=None) -> bool:
         # prels('CaseSeq.match %s'% self.delim, elems, show=1)
         delimord = [':',',',';']
         dmInds = {delimord[i] : i for i in range(len(delimord))}
@@ -542,3 +542,4 @@ class CaseDotName(SubCase, SolidCase):
         objExpr = subs[0]
         # print('O.dot:setSub', objExpr)
         base.setObj(objExpr)
+        return base

--- a/cases/utils.py
+++ b/cases/utils.py
@@ -144,7 +144,7 @@ class OperSplitter:
         return inst
 
 
-    def mainOper(self, elems:list[Elem])-> int:
+    def mainOper(self, elems:list[Elem], lesser=None)-> int:
         '''
         Find the main operator in the string.
         First operator with lowest priority from the end will be returned.
@@ -162,8 +162,16 @@ class OperSplitter:
         
         lowestPrior = len(self.priorGroups) - 1
         leftOfRarr = False # [\] word [, word]
+        passed = False
         
         for prior in range(lowestPrior, -1, -1):
+            if lesser is not None:
+                if passed:
+                    # It means that the expected operator hasn't been found
+                    # print('~')
+                    return -1
+                if lesser in self.priorGroups[prior]:
+                    passed = True
             curPos = lem
             # obr='([{'
             # cbr = ')]}'
@@ -208,8 +216,6 @@ class OperSplitter:
                     if lebr:
                         last = inBrs.pop() # change br stack
                         lebr = len(inBrs)
-                        # print('inbr pop: ',last, '>>', inBrs)
-                    # dprint(' << ', etx, last)
                     if i == 0 and etx in self.priorGroups[prior]:
                         # print('end of prior / open', obr)
                         return 0
@@ -273,6 +279,8 @@ KEYWORDS_R = ['func','if','else','for','return','struct','match','enum','while',
 KEYR_RX = re.compile('func|if|for|while|match|enum|struct|else|import|return')
 rSolOpers = ['.','~>', '...']
 _bpairs = {'(':')', '[':']', '{':'}'}
+_rob = list('}])')
+_rcb = list('([{')
 
 
 def isSolidExpr(elems:list[Elem], getLast=None, skipKeywords = False):
@@ -300,9 +308,9 @@ def isSolidExpr(elems:list[Elem], getLast=None, skipKeywords = False):
     fopers = _noSolidOpers
     # print('solid-fopers', fopers)
     opened = [] # brackets openede from right
-    # cbr = []
-    rob = list('}])')
-    rcb = list('([{')
+    # # cbr = []
+    # rob = list('}])')
+    # rcb = list('([{')
     # print('ss:', end=' ')
     found = -1
     for i in range(elen-1, -1, -1):
@@ -311,11 +319,11 @@ def isSolidExpr(elems:list[Elem], getLast=None, skipKeywords = False):
         # print('=>', '', etx, end=' ')
         # print('=>', '', etx)
         # et = el.type
-        if isLex(el, Lt.oper, rob):
+        if isLex(el, Lt.oper, _rob):
             # open brackets from right
             opened.append(el.text)
             continue
-        if isLex(el, Lt.oper, rcb):
+        if isLex(el, Lt.oper, _rcb):
             # close brackets
             if len(opened) == 0:
                 # posibly multiline expr

--- a/cases/utils.py
+++ b/cases/utils.py
@@ -248,7 +248,7 @@ class OperSplitter:
 
                     return curPos # The main Result
         if isLex(elems[0], Lt.oper, unaryOperators):
-            # dprint('oper-found> unary [0 : %s]' % elems[0].text ) 
+            # print('oper-found> unary [0 : %s]' % elems[0].text ) 
             return 0
         return -1 # debug output, won't happened in real case
 
@@ -325,7 +325,7 @@ def isSolidExpr(elems:list[Elem], getLast=None, skipKeywords = False):
             if _bpairs[etx] != lastObr:
                 # incorrect brackets pair in closing
                 raise InterpretErr(f"incorrect brackets pair in closing `{etx}{_bpairs[etx]}`")
-                return False, -1
+                # return False, -1
             if len(opened) == 0 and getLast:
                 # last closed part found in solidExpr
                 if found == -1:

--- a/nodes/control.py
+++ b/nodes/control.py
@@ -176,6 +176,7 @@ class MatchExpr(ControlBlock):
         vv = mval
         mval = var2val(mval)
         # print('Match. mval', self.match, vv, '::',  mval)
+        # print('M !-')
         for cs in self.cases:
             mctx = Context(ctx)
             cs.doExp(mctx)

--- a/nodes/match_patterns.py
+++ b/nodes/match_patterns.py
@@ -91,7 +91,7 @@ class MCType(MatchingPattern):
         
     def match(self, val:Val):
         xtype = self.xtype.get()
-        # print('MCType', val, val.getType(), ' :: ', xtype, xtype.get())
+        # print('MCType', val.getType(), ' :: ',  xtype.get(), ' ->>', valHasType(val, xtype))
         return valHasType(val, xtype)
         # return equalType(var2val(val), xtype)
 
@@ -148,10 +148,6 @@ class MCObjMember(MatchingPattern):
         return exp.getVal() == val.getVal()
 
 
-class MCElem(MatchingPattern):
-    ''' element of complex pattern '''
-
-
 class MCRegexp(MatchingPattern):
     ''' re`` !- ..
         re`pattern`mix !-
@@ -170,6 +166,24 @@ class MCRegexp(MatchingPattern):
         if not isinstance(val.getType(), TypeString):
             return False
         return self.pattern.match(val)
+
+
+class MTGroup(MatchingPattern):
+
+    def __init__(self, expVal:Expression,  src=None):
+        super().__init__(src)
+        self.exp:Expression = expVal
+
+    def do(self, ctx:Context):
+        self.exp.do(ctx)
+        
+    def match(self, val:StringVal):
+        # print('(expr).match', self.exp)
+        return self.exp.match(val)
+
+
+class MCElem(MatchingPattern):
+    ''' element of complex pattern '''
 
 
 # ------------------------ Sub-elements of sequence ---------------------- #
@@ -290,7 +304,6 @@ class MCQMark(MCSub):
         
         '''
         return True
-
 
 # -------------------- Ordered sequences ---------------- #
 

--- a/parser.py
+++ b/parser.py
@@ -25,11 +25,12 @@ nnChar = '_@$abcdefghijklmnopqrstuvwxyz' + 'abcdefghijklmnopqrstuvwxyz'.upper()
 c_quot = "\'\"`"
 c_regex = '| / % '
 
-opers = [n for n in (
+_opers = [n for n in (
     '; , ... $$ .. ** ++ -- += -= *= /= %=  && || == != <= >= << >>'
     ' => ?> !?> -> <- !- := ?: /: !: :? :> :: =~ ?~ /~ ~> ^/'
     ' < > = + - * / | \\ { } [ ] . , : ? ~ ! % ^ & * $ ( )').split(' ') if n]
 # ' """ \'\'\' ``` '
+_mopers = { n:1 for n in _opers}
 
 
 # if i > 0 and el.text in ['-', '+', '!', '~'] and elems[i-1].type == Lt.oper and elems[i-1].text != ')'
@@ -97,7 +98,7 @@ def charType(prevs:int, s:str, esc_map=None) -> int:
     return base
 
 def findOper(oper, res):
-    for n in opers:
+    for n in _opers:
         # dprint('>> ', oper, n)
         if oper.startswith(n):
             # first correct oper has been found

--- a/readme.md
+++ b/readme.md
@@ -102,12 +102,12 @@ Content:
     2. [Usage](#112-enum-usage)
     3. [Matching >>>](#2310-enum-elements)
 
-14. #### Builtin (native) functions and methods
+12. #### Builtin (native) functions and methods
     1. [Global functions: print, iter, etc.](#141-global-native-functions)
     2. [Bind native function as a method `[1,2].join(',')`](#142-binding-method-for-type)
     3. [Methods are already bound](#143-methods--are-already-bound-to-types)
 
-15. #### [Functional features](#15-functional-programming-features)  
+13. #### [Functional features](#15-functional-programming-features)  
     1. [Lambdas `x -> x ** 2`](#151-lambda-functions-right-arrow--)  
     2. [high-order functions `f1(f2)`](#152-high-order-functions)
     3. [Function as object](#153-function-as-an-object)
@@ -119,18 +119,18 @@ Content:
     9. [Builtin `compose`, `g * f`](#159-builtin-composition)
     10. [apply `f $ x`](#1592-apply-operator)
 
-20. Inline syntax.  
+14. Inline syntax.  
     [Few-expressions block `x=1 ; f(x)`](#20-one-line-block---operators)  
     [Controls (`if`, `for`, etc) `/:`](#20-one-line-block---operators)  
 
-21. #### [String features](#21-string-features)
+15. #### [String features](#21-string-features)
     1. [insert `"%s" << x`](#211-percent-formatting)
     2. [include `~"{x}"`](#212-format-by-including-expressions)
     3. [base functions](#213-string-functions)
 
-22. [Modules. `import`](#22-import-modules)
+16. [Modules. `import`](#22-import-modules)
 
-23. #### `match`-statement
+17. #### `match`-statement
     1. [Match, cases, /:`](#23-match-statement)
     2. [List and tuple `[0,x,_,?,*]` `(_,?,*)`](#232-matching-list-and-tuple)
     3. [Dict pattern `{'a':a, _:_, *}`](#233-matching-dict)
@@ -141,7 +141,7 @@ Content:
     8. [Regexp case ```re`abc` ```](#238-regexp-case)
     9. [Type pattern `::`](#239-type-matching-_int)
 
-25. Regular expression:
+18. Regular expression:
     1. [Base syntax ```re`[abc]`i```](#251-regular-expressions-re)
     2. [match `=~`](#252-regexp-match-)
     3. [find `?~`](#253-regexp-find-)
@@ -2750,6 +2750,20 @@ match n
     # tuple
     (3,4,5) /: expr
 ```
+
+Note. Commas in tuple.  
+Empty tuple pattern can have comma or not.  
+Tuple with 1 elem should have comma in the end.  
+```python
+match n:
+    () /: 1 # valid  empty tuple
+    (2,) /: 2 # valid tuple with 1 elem
+    (3) /: 0 # not a tuple, just number in brackets  
+    (:: int) /: 0 # still not a tuple
+    ((5,)) 0 # 1-sub tuple in outer brackets
+```
+
+
 2. Variable in collection `[a,b]`, `(a,b,c)`, named non-constant element.  
     Var in pattern is matched with any element and will be assigned with the value according to position if pattern will be matched.  
     Assigned var can be used in the sub block of current match-case.  

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -163,6 +163,67 @@ class TestDev(TestCase):
 
 """
 
+
+    def test_interpret_mt_cases(self):
+        
+        data = r'''
+        #= solid
+        12
+        []
+        ()
+        (,)
+        {}
+        _{}
+        aa{}
+        a :: int
+        b :: int | float
+        c :: A | list
+        1 | 2 | 3
+        ::A|B|C
+        
+        () | {}
+        :: A
+        :: a | int
+        :: A | B
+        (:: int, )
+        [:: int,]
+        (:: int)
+        
+        
+        #= bugs
+        
+        '''
+        data = norm(data[1:]).splitlines()
+        for src in data:
+            if '' == src.strip():
+                continue
+            if src.startswith('#'):
+                continue
+            
+            # print('>', src)
+            # src = src.replace('$/N', '\n')
+            src = 'match n\n    %s' % src
+
+            tlines = splitLexems(src)
+            # print('', [[(l.val, Lt.name(l.ltype)) for l in n.lexems] for n in tlines])
+            clines:CLine = elemStream(tlines)
+            # print('', [c for c in clines])
+            try:
+                expTree:Module = lex2tree(clines)
+                MatchExpr, CaseExpr
+                # print('tt1>', expTree.subs[0].cases[0].expect.__class__.__name__)
+                # print('tt1>', expTree.subs[0].__class__.__name__)
+            except LangError as ex:
+                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n!! Error LangError:', ex.msg)
+                self.fail()
+                # raise ex
+            except Exception as ex:
+                # print('`=`=`=`=`=`=`=`\n!!Error Exception', ex.args)
+                self.fail()
+                # raise ex
+
+
+
     def interpret_base_cases(self):
         
         data = r'''
@@ -301,7 +362,7 @@ class TestDev(TestCase):
     #     prof.runctx('self.interpret_base_cases()', globals(), locals())
         
 
-    def test_base_lang_cases(self):
+    def _test_base_lang_cases(self):
         self.interpret_base_cases()
 
     def _test_code3(self):

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -147,7 +147,7 @@ class TestDev(TestCase):
         
         TODO: add builtin compare() for base type: string, tuple, bytes.
         
-        TODO: refactor tree.py from loops of cases to pattern-tree
+        DONE: refactor tree.py from loops of cases to pattern-tree
         1) find common cases:
             solid -> in-brackets, dot.name, solid(brackets), solid-rUnar, single control-keywords, var, val, 
             no-solid -> definitions, control-statements, bin-opers, 
@@ -155,215 +155,17 @@ class TestDev(TestCase):
         2.2) refactor list-like expressions to avoid multiple check items in []-brackets
             first check solid []-case, then find case in []-cases:
             list, slice, iter-gen, list-gen, bytes
+        
+        TODO: Optimize mtCases using prepared data from upper limit-cases
+        
     '''
 
     _ = r"""
 # guides
-
+res = []
 
 """
 
-
-    def test_interpret_mt_cases(self):
-        
-        data = r'''
-        #= solid
-        12
-        []
-        ()
-        (,)
-        {}
-        _{}
-        aa{}
-        a :: int
-        b :: int | float
-        c :: A | list
-        1 | 2 | 3
-        ::A|B|C
-        
-        () | {}
-        :: A
-        :: a | int
-        :: A | B
-        (:: int, )
-        [:: int,]
-        (:: int)
-        
-        
-        #= bugs
-        
-        '''
-        data = norm(data[1:]).splitlines()
-        for src in data:
-            if '' == src.strip():
-                continue
-            if src.startswith('#'):
-                continue
-            
-            # print('>', src)
-            # src = src.replace('$/N', '\n')
-            src = 'match n\n    %s' % src
-
-            tlines = splitLexems(src)
-            # print('', [[(l.val, Lt.name(l.ltype)) for l in n.lexems] for n in tlines])
-            clines:CLine = elemStream(tlines)
-            # print('', [c for c in clines])
-            try:
-                expTree:Module = lex2tree(clines)
-                MatchExpr, CaseExpr
-                # print('tt1>', expTree.subs[0].cases[0].expect.__class__.__name__)
-                # print('tt1>', expTree.subs[0].__class__.__name__)
-            except LangError as ex:
-                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n!! Error LangError:', ex.msg)
-                self.fail()
-                # raise ex
-            except Exception as ex:
-                # print('`=`=`=`=`=`=`=`\n!!Error Exception', ex.args)
-                self.fail()
-                # raise ex
-
-
-
-    def interpret_base_cases(self):
-        
-        data = r'''
-        #= solid
-        12
-        12.5
-        0xdef
-        0b101
-        name
-        @debug
-        return
-        break
-        continue
-        if true$/N    2$/Nelse$/N    3
-        _
-        obj.aaa
-        []
-        [1,2,3]
-        [2 .. 5]
-        [n ; n <- nums; n != 5]
-        [11 22 fe]
-        0x[12 34 fe dc]
-        nums[1]
-        nums[1:end]
-        [- 100]
-        [a * b]
-        [[1,2,3]]
-        [[]]
-        [obj.memb]
-        [foo()]
-        
-        foo(1)
-        f1().aaa.f2().bbb[1+2].f3()
-        Abc{}
-        Abc{a:1}
-        'Hello 1'
-        `Hello 2`
-        foo()
-        (1)
-        """Hello\n 3"""
-        g'A'
-        re'[0-9a-f]?[soda]{1,5}'
-        re`abc\w+\s+`ui
-        ~"Format {a} {f()}"
-        foo~>
-        args...
-        (1,2,3)
-        {'a': 'bbb'}
-        {a:11, 'b':234, c: [1,2]}
-        (a + b - 13 / 44 * foo() - obj.val)
-        foo~>(1)(2)
-        true
-        null
-        
-        #== not solid
-        a + b
-        a = 13
-        a = a + b
-        func foo()
-            1
-        
-        struct Abc a:int, b:string
-        
-        struct C(B) x:int
-        
-        struct AAbbbc
-            a:int
-            b: string
-        
-        if x < 5
-            y = 80
-        for i <- [1..5]
-        for i=0; i < 5; i += 1
-        
-        res <- (1,2)
-        \ x -> x
-        \ x, y -> x + y - foo()
-        (a, b, c) -> a + b + c
-        @debug 123 Hello debug )
-        if 1 /:  if 123 /: 2
-        while a < 5
-        match n
-        if x
-        return 14
-        return (a + b)
-        import mod
-        import mod > *
-        import mymodule > foo f1, bar f2
-        enum Abc
-        1, 2, 3
-        aa; bbb ;c
-        a:int
-        foo:function
-        f00 * bar $ arg
-        foo * bar~>(1)(2) $ arg
-        a :: int
-        ab: A|B = null
-        ff = x -> x + 2
-        
-        ## match cases
-        
-        match nn$/N  a :: int
-        match nn$/N  a :: int|float
-        match nn$/N  1 | 2 | 3
-        match nn$/N  () | {}
-        match nn$/N  :: A
-        match nn$/N  A{}
-        
-        
-        #= bugs
-        
-        '''
-        data = norm(data[1:]).splitlines()
-        for src in data:
-            if '' == src.strip():
-                continue
-            src = src.replace('$/N', '\n')
-
-            tlines = splitLexems(src)
-            # print('', [[(l.val, Lt.name(l.ltype)) for l in n.lexems] for n in tlines])
-            clines:CLine = elemStream(tlines)
-            # print('', [c for c in clines])
-            try:
-                expTree = lex2tree(clines)
-            except LangError as ex:
-                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n!! Error LangError:', ex.msg)
-                self.fail()
-                # raise ex
-            except Exception as ex:
-                # print('`=`=`=`=`=`=`=`\n!!Error Exception', ex.args)
-                self.fail()
-                # raise ex
-
-    # def test_interpret_profile(self):
-    #     ''' '''
-    #     prof.runctx('self.interpret_base_cases()', globals(), locals())
-        
-
-    def _test_base_lang_cases(self):
-        self.interpret_base_cases()
 
     def _test_code3(self):
         ''' '''

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -1762,18 +1762,21 @@ class TestFuncs(TestCase):
             ('func u:User setName(name:string)', CaseMethodDef),
             ('func setName(name:string)', CaseFuncDef),
         ]
+        matcher = caseMatcher()
         for code, ctype in data:
             # dprint('Code:', code)
             # code = norm(code[1:])
             tlines = splitLexems(code)
             clines:CLine = elemStream(tlines)
             elems = clines[0].code
-            cases = getCases()
-            for cs in cases:
-                if cs.match(elems):
-                    # dprint('#tt found cae: ', cs, 'exp:', ctype)
-                    self.assertIsInstance(cs, ctype)
-                    break
+            lineInfo = CMatchInfo(elems)
+            cs = matcher.find(lineInfo)
+            self.assertIsInstance(cs, ctype)
+            # cases = getCases()
+            # for cs in cases:    
+            #     if cs.match(elems):
+            #         # dprint('#tt found cae: ', cs, 'exp:', ctype)
+            #         break
 
 
     def test_func_return(self):

--- a/tests/test_interpret_tree.py
+++ b/tests/test_interpret_tree.py
@@ -1,0 +1,247 @@
+''' '''
+
+
+
+from unittest import TestCase, main
+
+import lang
+import typex
+from lang import Lt, Mk, CLine
+from parser import splitLine, splitLexems, charType, splitOper, elemStream
+from vars import *
+from vals import numLex
+# import context
+from context import Context
+from bases.strformat import *
+# from nodes.structs import *
+from tree import *
+from eval import rootContext, moduleContext
+
+from cases.utils import *
+from nodes.tnodes import Var
+from objects.func import Function
+from nodes.func_expr import setNativeFunc
+from bases.over_ctx import FuncOverSet
+from tests.utils import *
+from libs.regexp import *
+from nodes.func_features import *
+
+
+import cProfile as prof
+import pdb
+
+
+            
+class TestInterpretTree(TestCase):
+
+
+
+    def test_interpret_mt_cases(self):
+        
+        data = r'''
+        #= solid
+        12
+        []
+        ()
+        (,)
+        {}
+        _{}
+        aa{}
+        a :: int
+        b :: int | float
+        c :: A | list
+        1 | 2 | 3
+        ::A|B|C
+        
+        () | {}
+        :: A
+        :: a | int
+        :: A | B
+        (:: int, )
+        [:: int,]
+        (:: int)
+        
+        
+        #= bugs
+        
+        '''
+        data = norm(data[1:]).splitlines()
+        for src in data:
+            if '' == src.strip():
+                continue
+            if src.startswith('#'):
+                continue
+            
+            # print('>', src)
+            # src = src.replace('$/N', '\n')
+            src = 'match n\n    %s' % src
+
+            tlines = splitLexems(src)
+            # print('', [[(l.val, Lt.name(l.ltype)) for l in n.lexems] for n in tlines])
+            clines:CLine = elemStream(tlines)
+            # print('', [c for c in clines])
+            try:
+                expTree:Module = lex2tree(clines)
+                MatchExpr, CaseExpr 
+                # print('tt1>', expTree.subs[0].cases[0].expect.__class__.__name__)
+                self.assertIsInstance(expTree.subs[0].cases[0].expect, MatchingPattern)
+            except LangError as ex:
+                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n!! Error LangError:', ex.msg)
+                self.fail()
+                # raise ex
+            except Exception as ex:
+                # print('`=`=`=`=`=`=`=`\n!!Error Exception', ex.args)
+                self.fail()
+                # raise ex
+
+
+
+    def interpret_base_cases(self):
+        
+        data = r'''
+        #= solid
+        12
+        12.5
+        0xdef
+        0b101
+        name
+        @debug
+        return
+        break
+        continue
+        if true$/N    2$/Nelse$/N    3
+        _
+        obj.aaa
+        []
+        [1,2,3]
+        [2 .. 5]
+        [n ; n <- nums; n != 5]
+        [11 22 fe]
+        0x[12 34 fe dc]
+        nums[1]
+        nums[1:end]
+        [- 100]
+        [a * b]
+        [[1,2,3]]
+        [[]]
+        [obj.memb]
+        [foo()]
+        
+        foo(1)
+        f1().aaa.f2().bbb[1+2].f3()
+        Abc{}
+        Abc{a:1}
+        'Hello 1'
+        `Hello 2`
+        foo()
+        (1)
+        """Hello\n 3"""
+        g'A'
+        re'[0-9a-f]?[soda]{1,5}'
+        re`abc\w+\s+`ui
+        ~"Format {a} {f()}"
+        foo~>
+        args...
+        (1,2,3)
+        {'a': 'bbb'}
+        {a:11, 'b':234, c: [1,2]}
+        (a + b - 13 / 44 * foo() - obj.val)
+        foo~>(1)(2)
+        true
+        null
+        
+        #== not solid
+        a + b
+        a = 13
+        a = a + b
+        func foo()
+            1
+        
+        struct Abc a:int, b:string
+        
+        struct C(B) x:int
+        
+        struct AAbbbc
+            a:int
+            b: string
+        
+        if x < 5
+            y = 80
+        for i <- [1..5]
+        for i=0; i < 5; i += 1
+        
+        res <- (1,2)
+        \ x -> x
+        \ x, y -> x + y - foo()
+        (a, b, c) -> a + b + c
+        @debug 123 Hello debug )
+        if 1 /:  if 123 /: 2
+        while a < 5
+        match n
+        if x
+        return 14
+        return (a + b)
+        import mod
+        import mod > *
+        import mymodule > foo f1, bar f2
+        enum Abc
+        a, b, c = 1, 2, 3
+        aa; bbb ;c
+        a:int
+        foo:function
+        f00 * bar $ arg
+        foo * bar~>(1)(2) $ arg
+        a :: int
+        ab: A|B = null
+        ff = x -> x + 2
+        
+        ## match cases
+        
+        match nn$/N  a :: int
+        match nn$/N  a :: int|float
+        match nn$/N  1 | 2 | 3
+        match nn$/N  () | {}
+        match nn$/N  :: A
+        match nn$/N  A{}
+        
+        
+        #= bugs
+        
+        '''
+        data = norm(data[1:]).splitlines()
+        for src in data:
+            if '' == src.strip():
+                continue
+            if src.startswith('#'):
+                continue
+            src = src.replace('$/N', '\n')
+
+            tlines = splitLexems(src)
+            # print('', [[(l.val, Lt.name(l.ltype)) for l in n.lexems] for n in tlines])
+            clines:CLine = elemStream(tlines)
+            # print('', [c for c in clines])
+            try:
+                expTree = lex2tree(clines)
+                # print('tt1>', expTree.subs, src) # 
+                self.assertIsInstance(expTree.subs[0], Expression)
+            except LangError as ex:
+                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n!! Error LangError:', ex.msg)
+                self.fail()
+                # raise ex
+            except Exception as ex:
+                # print('`=`=`=`=`=`=`=`\n!!Error Exception', ex.args)
+                self.fail()
+                # raise ex
+
+    def _test_interpret_profile(self):
+        ''' profiling test '''
+        prof.runctx('self.interpret_base_cases()', globals(), locals())
+    
+
+    def test_base_lang_cases(self):
+        self.interpret_base_cases()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/tests/test_interpret_tree.py
+++ b/tests/test_interpret_tree.py
@@ -4,35 +4,39 @@
 
 from unittest import TestCase, main
 
-import lang
-import typex
+# import lang
+# import typex
 from lang import Lt, Mk, CLine
 from parser import splitLine, splitLexems, charType, splitOper, elemStream
 from vars import *
-from vals import numLex
+# from vals import numLex
 # import context
-from context import Context
+# from context import Context
 from bases.strformat import *
 # from nodes.structs import *
 from tree import *
-from eval import rootContext, moduleContext
+# from eval import rootContext, moduleContext
 
-from cases.utils import *
-from nodes.tnodes import Var
-from objects.func import Function
-from nodes.func_expr import setNativeFunc
-from bases.over_ctx import FuncOverSet
+# from cases.utils import *
+# from nodes.tnodes import Var
+# from objects.func import Function
+# from nodes.func_expr import setNativeFunc
+# from bases.over_ctx import FuncOverSet
 from tests.utils import *
-from libs.regexp import *
-from nodes.func_features import *
+# from libs.regexp import *
+# from nodes.func_features import *
 
 
-import cProfile as prof
-import pdb
+# import cProfile as prof
+# import pdb
 
 
             
 class TestInterpretTree(TestCase):
+    '''
+    ## py -m cProfile -s tottime -m unittest
+
+    '''
 
 
 
@@ -72,14 +76,11 @@ class TestInterpretTree(TestCase):
             if src.startswith('#'):
                 continue
             
-            # print('>', src)
-            # src = src.replace('$/N', '\n')
             src = 'match n\n    %s' % src
 
             tlines = splitLexems(src)
             # print('', [[(l.val, Lt.name(l.ltype)) for l in n.lexems] for n in tlines])
             clines:CLine = elemStream(tlines)
-            # print('', [c for c in clines])
             try:
                 expTree:Module = lex2tree(clines)
                 MatchExpr, CaseExpr 
@@ -219,10 +220,9 @@ class TestInterpretTree(TestCase):
             tlines = splitLexems(src)
             # print('', [[(l.val, Lt.name(l.ltype)) for l in n.lexems] for n in tlines])
             clines:CLine = elemStream(tlines)
-            # print('', [c for c in clines])
             try:
                 expTree = lex2tree(clines)
-                # print('tt1>', expTree.subs, src) # 
+                # print('tt1>', expTree.subs, src)
                 self.assertIsInstance(expTree.subs[0], Expression)
             except LangError as ex:
                 print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n!! Error LangError:', ex.msg)
@@ -233,9 +233,9 @@ class TestInterpretTree(TestCase):
                 self.fail()
                 # raise ex
 
-    def _test_interpret_profile(self):
-        ''' profiling test '''
-        prof.runctx('self.interpret_base_cases()', globals(), locals())
+    # def _test_interpret_profile(self):
+    #     ''' profiling test '''
+    #     prof.runctx('self.interpret_base_cases()', globals(), locals())
     
 
     def test_base_lang_cases(self):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -155,18 +155,18 @@ class TestMatch(TestCase):
             
         for n <- nn
             match n
-                :: (int|float) /: res <- 1
-                n :: (A|B) /: res <- 4
-                n :: (C|bool) /: res <- 5
-                [::A, ::(B|C)] /: res <- 7
-                (::A, ::(B|C)) /: res <- 8
-                ::(AA|GG) :? n.n ?> [22,23,24] /: res <- 500 + n.n
-                ::(FF|GG) | ::(HH|JJ) /: res <- 300 + n.n
+                :: int|float /: res <- 1
+                n :: A|B /: res <- 4
+                n :: C|bool /: res <- 5
+                [::A, ::B|C] /: res <- 7
+                (::A, ::B|C) /: res <- 8
+                ::AA|GG :? n.n ?> [22,23,24] /: res <- 500 + n.n
+                (::FF|GG) | (::HH|JJ) /: res <- 300 + n.n
                 (::AA, ::CC) | (::FF, ::DD) /: res <- (400 + n[0].n, 400 + n[1].n)
-                :: (string|list) /: res <- 2
-                :: (dict|tuple) /: res <- 3
-                :: (string|list|D) | :: dict /: res <- 6
-                ::(AA|BBB|CC|DD|EE) /: res <- 200 + n.n
+                :: string|list /: res <- 2
+                :: dict|tuple /: res <- 3
+                (:: string|list|D) | (:: dict) | (1) | (1,2) /: res <- 6
+                (::AA|BBB|CC|DD|EE) /: res <- 200 + n.n
                 _ /: res <- 199
         
         # print('res = ', res)
@@ -193,11 +193,12 @@ class TestMatch(TestCase):
         struct C c:string
         struct D
         struct BB(B) bb:int
+        struct E
         
         n = A{}
         nn = [1, 1.1, true, [1], (1,2), 'asd', {1:11, 2:22}, 
             A{}, B{}, C{}, D{}, [A{}, B{}], [A{}, C{}], 
-            BB{}, (A{}, BB{}), (A{}, C{}),]
+            BB{}, (A{}, BB{}), (A{}, C{}), E{}]
             
         for n <- nn
             match n
@@ -208,7 +209,8 @@ class TestMatch(TestCase):
                 (a::A, b::(B|C)) /: res <- 8
                 n :: (string|list) /: res <- 2
                 n :: (dict|tuple) /: res <- 3
-                n :: (string|list|D) | n :: dict /: res <- 6
+                (a :: string|list|D) | (a :: dict) /: res <- 6
+                (n :: string|list|E) | (n :: dict) /: res <- 9
                 _ /: res <- 199
         # (int|list|bool)
         # print('res = ', res)
@@ -220,7 +222,7 @@ class TestMatch(TestCase):
         ctx = rCtx.moduleContext()
         trydo(ex, ctx)
         rvar = ctx.get('res').get()
-        exv = [0, 1, 1, 5, 2, 3, 2, 3, 4, 4, 5, 6, 7, 7, 4, 8, 8]
+        exv = [0, 1, 1, 5, 2, 3, 2, 3, 4, 4, 5, 6, 7, 7, 4, 8, 8, 9]
         self.assertEqual(exv, rvar.vals())
 
     def test_novar_type_struct(self):
@@ -244,7 +246,7 @@ class TestMatch(TestCase):
             match n
                 :: A /: res <- 10
                 :: B /: res <- 11
-                :: C | ::D /: res <- 12
+                (::C) | (::D) /: res <- 12
                 [:: A, ::B] | [::C, ::D] /: res <- 13
                 [_{}, _{}]     /: res <- 14
                 _ /: res <- 999
@@ -283,7 +285,7 @@ class TestMatch(TestCase):
             match n
                 a :: A /: res <- (10 , n, a)
                 :: B /: res <- (11 , n)
-                ::C | ::D /: res <- (16 , n)
+                (:: C) | (:: D)  /: res <- (16 , n)
                 [a::A, b::(B)] /: res <- (12 , n, a, b)
                 (a::A, b::(C)) /: res <- (13 , n, a, b)
                 [a::D, _{}] /: res <- (15 , n, a)
@@ -331,10 +333,10 @@ class TestMatch(TestCase):
         ]
         for nn <- nns
             match nn
-                [re`[a-d]+`] | (re`[qwerty]+`) /: res <- (nn, 1)
-                [re`[\d+]+`] | (re`[0-3]+`) | [re`0x[0-9a-f]{2,}`] /: res <- (nn, 2)
+                [re`[a-d]+`] | (re`[qwerty]+`,) /: res <- (nn, 1)
+                [re`[\d+]+`] | (re`[0-3]+`,) | [re`0x[0-9a-f]{2,}`] /: res <- (nn, 2)
                 [re`^[\d+]+$`, re`.+`] | (re`^[a-z]+$`, re`^[^\s]+$`)  /: res <- (nn, 3)
-                [re`[w-z]+`] | (re`[w-z]+`) | {re`[w-z]+`:_}  /: res <- (nn, 4)
+                [re`[w-z]+`] | (re`[w-z]+`,) | {re`[w-z]+`:_}  /: res <- (nn, 4)
                 {re`.+`:1} /: res <- (nn, 5)
                 {re`0x[\d0-f]+$`:_} /: res <- (nn, 51)
                 {re`^Red.+$`: a:: string, re`^Green.+$`: b:: string} /: res <- (nn, (a, b), 52)
@@ -349,7 +351,7 @@ class TestMatch(TestCase):
                 [A{a1:re`x+`}] /: res <- (nn, 75)
                 
                 [*] /: res <- (nn, 881)
-                (*) /: res <- (nn, 882)
+                (*,) /: res <- (nn, 882)
                 {*}  /: res <- (nn, 883)
                 _ /: res <- (nn, 999)
         
@@ -412,14 +414,14 @@ class TestMatch(TestCase):
                 [a::tuple] /: res <- (nn, (a,), '[tuple]', 15)
                 [::string, ::tuple] /: res <- (nn, '[strn, tuple]', 16)
                 
-                (::int) /: res <- (nn, '(int)', 20)
-                (x::bool) /: res <- (nn, ('x:', x), '(bool)', 21)
+                (::int,) /: res <- (nn, '(int)', 20)
+                (x::bool,) /: res <- (nn, ('x:', x), '(bool)', 21)
                 (::int, ::float, ::bool) /: res <- (nn, '(int, float, bool)', 22)
                 (a::int, b::float, c::bool, d::string) /: res <- (nn, '(int, float, bool, string)', 23)
                 (a::string, b::string) /: res <- (nn, 'strn, strn', 24)
                 [a :: tuple, b::list] /: res <- (nn, [a, b], '(tuple, list)', 25)
                 (a::string, b::list) /: res <- (nn, '(strn, list)', 26)
-                (::list) /: res <- (nn, '(list)', 27)
+                (::list,) /: res <- (nn, '(list)', 27)
                 
                 {key::string : vv::int} /: res <- (nn, (key, vv), '{}', 30)
                 {k :: int : 'c1'} /: res <- (nn, '{k::int : "c1" }', 31)
@@ -594,7 +596,7 @@ class TestMatch(TestCase):
                 [{}, {}] /: res <- (nn, 3)
                 ({}, {}) /: res <- (nn, 4)
                 
-                [(1), (*)] /: res <- (nn, 5)
+                [(1), (*,)] /: res <- (nn, 5)
                 ([3], [*]) /: res <- (nn, 6)
                 [{5:5}, {*}] /: res <- (nn, 7)
                 ({7:7}, {*}) /: res <- (nn, 8)
@@ -604,20 +606,20 @@ class TestMatch(TestCase):
                 
                 [{1:[(), ()], 2:[(), ()]}, {3:[(), ()], 4:[(), ()]}] /: res <- (nn, 11)
                 [{1:()}] /: res <- (nn, 12)
-                ({1:[]}) /: res <- (nn, 13)
+                ({1:[]},) /: res <- (nn, 13)
                 [{1:_}] /: res <- (nn, 41)
-                [({1:_})] /: res <- (nn, 42)
-                ([{1:_}]) /: res <- (nn, 43)
+                [({1:_},)] /: res <- (nn, 42)
+                ([{1:_}],) /: res <- (nn, 43)
                 
                 [A{a1:11}, _] /: res <- (nn, 14)
                 [A{a1:11}] /: res <- (nn, 141)
-                (A{a1:11}) /: res <- (nn, 142)
+                (A{a1:11},) /: res <- (nn, 142)
                 [(A{}, 11), (B{}, 22)] /: res <- (nn, 143)
                 ([A{}, B{}], [B{}, C{}]) /: res <- (nn, 15)
                 {'a':A{}, 'b':B{}} /: res <- (nn, 16)
                 
                 [*] /: res <- (nn, 917)
-                (*) /: res <- (nn, 918)
+                (*,) /: res <- (nn, 918)
                 {*} /: res <- (nn, 919)
                 _ /: res <- (nn, 999)
         
@@ -666,7 +668,7 @@ class TestMatch(TestCase):
                 0 | null | "" | [] /: res <- (nn, 0)
                 [1,2,3] | (1,2,3) | {'a':_, 'b':_, 'c':_} /: res <- (nn, 1)
                 A{a1:1} | B{b1:2} | C{c1:'c3'} /: res <- (nn, 2)
-                [*] | (*) | {*}  /: res <- (nn, 888)
+                [*] | (*,) | {*}  /: res <- (nn, 888)
                 _ /: res <- (nn, 999)
         
         # print(res)
@@ -831,7 +833,7 @@ class TestMatch(TestCase):
                 TypeC{nums:[a, b, c]} /: res <- [n, (a,b,c), 32]
                 TypeD{fd:{'a':aval,*}} /: res <- [n, (aval,), 41]
                 TypeD{fl:[a, b, *]} /: res <- [n, (a,b), 42]
-                TypeD{ft:(a), fd:{b:c}, fl:[d]} /: res <- [n, (a,b,c,d), 43]
+                TypeD{ft:(a,), fd:{b:c}, fl:[d]} /: res <- [n, (a,b,c,d), 43]
                 TypeD{ft:(a,*)} /: res <- [n, (a,), 44]
                 TypeD{} /: res <- [n, 49]
                 _ /: res <- [n, 2999]
@@ -924,7 +926,7 @@ class TestMatch(TestCase):
                 1 /: res <- [n, 11]
                 2 | 3 /: res <- [n, 22]
                 4 | 5 | 6 /: res <- [n, 33]
-                (_) | [_] | {_:_} /: res <- [n, 101]
+                (_,) | [_] | {_:_} /: res <- [n, 101]
                 (a, *) | [a, *] | {a:_, _:_} /: res <- [n, (a,), 102]
                 {*} | 4444 /: res <- [n, 103]
                 _  /: res <- [n, 999]
@@ -964,7 +966,7 @@ class TestMatch(TestCase):
                 (a, _, ?,  9, *, b, c, 19, _, ?, *, d)   /: res <- [n, (a, b, c, d), 91]
                 (a, _, ?,  9, *, b, c, 19, _, ?, *)   /: res <- [n, (a, b, c), 92]
                 [*]      /: res <- [n, 1099]
-                (*)      /: res <- [n, 99]
+                (*,)      /: res <- [n, 99]
                 _ /: res <- [n, 5999]
             # print(res)
         # 
@@ -1080,7 +1082,7 @@ class TestMatch(TestCase):
                 (?, 5,?) /: res <- [n, 53]
                 (_, 5, ?) /: res <- [n, 54]
                 (5, ?, ?) /: res <- [n, 55]
-                (?) /: res <- [n, 11]
+                (?,) /: res <- [n, 11]
                 (1, ?, 3) /: res <- [n, 31]
                 (1, ?, ?, ?, 5) /: res <- [n, 51]
                 (3,_,?) /: res <- [n, 32]
@@ -1417,9 +1419,9 @@ class TestMatch(TestCase):
             # print('nn:', n)
             match n
                 () /: res <- [n, 11]
-                (2) /: res <- [n, 11]
-                (a) /: res <-   [n, (a,), 12]
-                (_) /: res <- [n, 19] # shouldn't be used because prev
+                (2,) /: res <- [n, 11]
+                (a,) /: res <-   [n, (a,), 12]
+                (_,) /: res <- [n, 19] # shouldn't be used because prev
                 (a,2) /: res <- [n, (a,), 13]
                 (a,b) /: res <- [n, (a,b), 14]
                 (a,_,3) /: res <- [n, (a,), 21]
@@ -1510,9 +1512,9 @@ class TestMatch(TestCase):
             match n
                 # 1 /: 1
                 () /: res <- [n, 101]
-                (1) /: res <-   [n, 102]
+                (1,) /: res <-   [n, 102]
                 (1,7) /: res <- [n, 103]
-                (_) /: res <- [n, 201]
+                (_,) /: res <- [n, 201]
                 (1,_) /: res <- [n, 202]
                 (_,2) /: res <- [n, 203]
                 (_,_) /: res <- [n, 204]

--- a/tree.py
+++ b/tree.py
@@ -130,41 +130,41 @@ complex
 # CaseWord -> CaseKeyword, CaseVar, CaseVal
 # CaseEndBrackets -> funcCall, collectElem, structConstr
 # CaseExprLeft: ObjMember, ListExtr, FuncCurry
-expCaseSolids:list[ExpCase] = [
-    CaseBreak(), CaseContinue(), CaseReturn(),  CaseElse(), 
+# expCaseSolids:list[ExpCase] = [
+#     CaseBreak(), CaseContinue(), CaseReturn(),  CaseElse(), 
     
-    CaseNumVal(), CaseVar(), CaseVar_(), 
-    CaseString(), CaseGlif(), CaseRegexp(), 
-    CaseDotName(), CaseRTildArroy(), 
+#     CaseNumVal(), CaseVar(), CaseVar_(), 
+#     CaseString(), CaseGlif(), CaseRegexp(), 
+#     CaseDotName(), CaseRTildArroy(), 
     
-    CaseListGen(), CaseBytes(), CaseBytesExplicit(),
-    CaseArgExtraList(), CaseArgExtraDict(),
-    CaseDictLine(), CaseListComprehension(), CaseSlice(), CaseCollectElem(), 
-    CaseTuple(), CaseList(),
+#     CaseListGen(), CaseBytes(), CaseBytesExplicit(),
+#     CaseArgExtraList(), CaseArgExtraDict(),
+#     CaseDictLine(), CaseListComprehension(), CaseSlice(), CaseCollectElem(), 
+#     CaseTuple(), CaseList(),
     
-    CaseFunCall(), CaseStructConstr(),
-    CaseBrackets(), CaseMString()
-]
+#     CaseFunCall(), CaseStructConstr(),
+#     CaseBrackets(), CaseMString()
+# ]
 
-# CaseService -> empty, debug, unclosed
-# CaseKeywordLeft -> definition, control, import
-# CaseOperators -> lambda, bin-common, inline-control, sequence, unarLeft
-#
-expCaseList:list[ExpCase] = [
-    CaseEmpty(), CaseDebug(),
-    # CaseUnclosedBrackets(),
-    CaseInlineSub(),
+# # CaseService -> empty, debug, unclosed
+# # CaseKeywordLeft -> definition, control, import
+# # CaseOperators -> lambda, bin-common, inline-control, sequence, unarLeft
+# #
+# expCaseList:list[ExpCase] = [
+#     CaseEmpty(), CaseDebug(),
+#     # CaseUnclosedBrackets(),
+#     CaseInlineSub(),
     
-    CaseImport(), 
-    CaseFuncDef(), CaseMethodDef(), # ident func, then - method
-    CaseIf(), CaseElse(), CaseWhile(), CaseFor(),  CaseMatch(), CaseReturnVal(),  
-    CaseMatchCase(),
-    CaseStructBlockDef(), CaseStructDef(), CaseEnum(),
+#     CaseImport(), 
+#     CaseFuncDef(), CaseMethodDef(), # ident func, then - method
+#     CaseIf(), CaseElse(), CaseWhile(), CaseFor(),  CaseMatch(), CaseReturnVal(),  
+#     CaseMatchCase(),
+#     CaseStructBlockDef(), CaseStructDef(), CaseEnum(),
     
-    CaseLambda(),
-    CaseSemic(), CaseBinOper(), CaseCommas(),
-    CaseLUnar(StrFormatter()),
-]
+#     CaseLambda(),
+#     CaseSemic(), CaseBinOper(), CaseCommas(),
+#     CaseLUnar(StrFormatter()),
+# ]
 
 patternMatchCasesSolid = [
     MT_Other(),
@@ -175,13 +175,35 @@ patternMatchCasesCplx = [
     MTPtGuard(), MTMultiCase(), MTTypedVal(), MTDuaColon(), MTMultiTyped(),
 ]
 
+def mtMatcher():
+    ''' case-tree of match-case cases. '''
+    # MTVal(), MTString(), MTRegexp(), MTList(), MTTuple(), MTDict(), MTStruct(), MTObjMember()
+    
+    # sqBrkLim = CaseOption(CaseBrkSquare(), [CaseListGen(), CaseBytes(), CaseListComprehension(), CaseList()])
+    # brkLim = CaseOption(CaseGenBrackets(), [sqBrkLim, CaseTuple(), CaseDictLine(), CaseBrackets()])
 
-def getCases()->list[ExpCase]:
-    return expCaseList
+    
+    wordLim = CaseOption(CaseWord(), [MT_Other(), MTVal()])
+    brkLim = CaseOption(CaseGenBrackets(), [MTList(), MTTuple(), MTDict(), MTParenth(), ])
+    strLim = CaseOption(CaseStr(), [MTString(), MTRegexp(),])
+    solidRight = CaseOptionPrepared(CaseSolidLeft(), [MTStruct(), MTObjMember(),])
+
+    solidLim = CaseOption(CaseSolid(), [wordLim, strLim, solidRight, brkLim])
+    
+    
+    operLim = CaseOptionPrepared(CaseOperLim(), [MTPtGuard(), MTTypedVal(), MTMultiCase(), MTMultiTyped(), ])
+    
+    nonSolLim = CaseOption(NonSolid(), [MTDuaColon(), operLim, MTMultiTyped(),])
+
+    fullMatcher = CaseMatchcher([solidLim, nonSolLim])
+    return fullMatcher
+
+# def getCases()->list[ExpCase]:
+#     return expCaseList
 
 
 def simpleExpr(expCase:ExpCase, elems)->Expression:
-    # dprint('#simple-case:', expCase)
+    # print('#simple-case:', expCase)
     return expCase.expr(elems)
 
 
@@ -204,6 +226,7 @@ def mtCases(elems:list[Elem], cases: list[ExpCase], parent:ExpCase=None)->Matchi
     return None
 
 
+
 def makePMatchExpr(elems:list[Elem], parent:ExpCase=None)->MatchingPattern:
     # print('#makePMatchExpr:', [(n.text, Lt.name(n.type)) for n in elems])
     # print('\n#tree-makePMatchExpr/1::', ' '.join(["'%s'"%n.text for n in elems]))
@@ -220,6 +243,9 @@ def makePMatchExpr(elems:list[Elem], parent:ExpCase=None)->MatchingPattern:
     raise InterpretErr('No current MTCase for `%s` ' % ''.join([n.text for n in elems]))
 
 
+
+__mtMatcher = mtMatcher()
+
 def complexExpr(expCase:SubCase, elems:list[Elem])->Expression:
     base, subs = expCase.split(elems)
     # print('#complex-case:', expCase.__class__.__name__, ' base:', base, subs)
@@ -228,11 +254,34 @@ def complexExpr(expCase:SubCase, elems:list[Elem])->Expression:
     if not expCase.sub():
         return base
     
+    # if isinstance(expCase, CaseMatchCase):
+    #     # pattern !- block
+    #     pattern =  makePMatchExpr(subs[0])
+    #     block = elems2expr(subs[1])
+    #     expCase.setSub(base, [pattern, block])
+    #     # print('complexExpr..CaseMatchCase', base)
+    #     return base
+    
     if isinstance(expCase, CaseMatchCase):
         # pattern !- block
-        pattern =  makePMatchExpr(subs[0])
+        mtElems = subs[0]
+        info = CMatchInfo(subs[0])
+        mtCase =  __mtMatcher.find(info)
+        if not mtCase:
+            raise EvalErr("Can't find the MTCase for source %s", elemStr(mtElems))
+        
+        # print('mt.found>', mtCase.__class__.__name__, '', elemStr(elems))
+        if mtCase.hasSubExpr():
+            pattr, subElems = mtCase.split(mtElems)
+            subExp = elems2expr(subElems)
+            # print('$3>', subExp)
+            pattr = mtCase.setSub(pattr, subExp)
+        else:
+            pattr = mtCase.expr(mtElems)
+        # print('mtc:', mtcase)
+        # pattern =  makePMatchExpr(subs[0])
         block = elems2expr(subs[1])
-        expCase.setSub(base, [pattern, block])
+        expCase.setSub(base, [pattr, block])
         # print('complexExpr..CaseMatchCase', base)
         return base
         
@@ -253,12 +302,28 @@ def complexExpr(expCase:SubCase, elems:list[Elem])->Expression:
     return base
 
 def makeExpr(expCase:ExpCase, elems:list[Elem])->Expression:
-    # dprint('makeExpr', [n.text for n in elems])
+    # print('makeExpr', expCase, [n.text for n in elems])
     if expCase.sub():
         return complexExpr(expCase, elems)
     return simpleExpr(expCase, elems)
 
-def subBtContext(blockContext:Expression):
+
+# def findMTcase(elems):
+#     info = CMatchInfo(elems)
+#     mtcase =  __mtMatcher.find(info)
+#     base, subs = mtcase.split(elems)
+    
+#     mcExpr = CaseMatchCase()
+#         # if isinstance(expCase, CaseMatchCase):
+#     # pattern !- block
+#     pattern =  makePMatchExpr(subs[0])
+#     block = elems2expr(subs[1])
+#     expCase.setSub(base, [pattern, block])
+#     # print('complexExpr..CaseMatchCase', base)
+#     return base
+
+
+def subBtContext(elems:list[Elem], blockContext:Expression):
     match blockContext:
         case MatchExpr():
             return CaseMatchCase()
@@ -268,6 +333,7 @@ def subBtContext(blockContext:Expression):
 ## py -m cProfile -s tottime -m unittest
 
 def caseMatcher():
+    ''' case-tree of common cases '''
     strLim = CaseOption(CaseStr(), [CaseRegexp(), CaseGlif(), CaseString(), CaseMString()])
     wordLim = CaseOption(CaseWord(), [CaseElse(), CaseBreak(), CaseContinue(), CaseReturn(), CaseVar_(), CaseNumVal(), CaseDebug(), CaseVar(), ])
     solidLeft = CaseOptionPrepared(
@@ -315,11 +381,11 @@ def elems2expr(elems:list[Elem], blockContext:Expression=None)->Expression:
     
     # check context-dependent
     if blockContext:
-        foundCase = subBtContext(blockContext)
+        foundCase = subBtContext(elems, blockContext)
     
     # # check Solid:
     # expSolid = isSolidExpr(elems)
-    # # print('\ntree.solid:', expSolid)
+    # print('tree-foundMT:', foundCase)
     # if not foundCase and expSolid:
     #     # print('elems2expr/isSolidExpr', expCaseSolids)
     #     for expCase in expCaseSolids:

--- a/tree.py
+++ b/tree.py
@@ -64,66 +64,6 @@ class StrFormatter(SFormatter):
         parts = self.fp.parse(src)
         return self.partsToExpr(parts)
 
-_1 = r''' 
-
-single
-
-    brackets
-    ()
-        (,), (expr)
-    []
-        list, slice, [iter: gen], [com;pre;hension], 0x[bytes], [by te s]
-    {}
-        dict
-    
-    right-brackets
-        func-call()
-        collect[elem]
-        struct{constr}
-    
-    expr-chain
-        obj.elem
-        list...
-        expr~>
-        
-        
-    text-line
-        string
-        glif
-        regexp
-    
-    numeric
-        int, float, bool, null
-    
-    word
-        _
-        var
-        keyword-single
-            else, continue, break, return-empty
-
-complex
-    empty, debug
-    unclosed-brackets
-    operator
-        bin-oper
-        unar-left
-    
-    sequence
-        n,n / n;n / n:n /
-    inline-sub /:
-    keyword-line
-        def
-            func, struct, enum, import
-        control
-            if, for, while, match
-            match-case
-        other
-            return-val
-    lambda
-    m-string?
-
-'''
-
 
 # CaseMString
 # CaseBrackets -> CaseBrRound, CaseBrSquare, CaseBrCurl
@@ -166,22 +106,17 @@ complex
 #     CaseLUnar(StrFormatter()),
 # ]
 
-patternMatchCasesSolid = [
-    MT_Other(),
-    MTVal(), MTString(), MTRegexp(), MTList(), MTTuple(), MTDict(), MTStruct(), MTObjMember(),
-]
+# patternMatchCasesSolid = [
+#     MT_Other(),
+#     MTVal(), MTString(), MTRegexp(), MTList(), MTTuple(), MTDict(), MTStruct(), MTObjMember(),
+# ]
 
-patternMatchCasesCplx = [
-    MTPtGuard(), MTMultiCase(), MTTypedVal(), MTDuaColon(), MTMultiTyped(),
-]
+# patternMatchCasesCplx = [
+#     MTPtGuard(), MTMultiCase(), MTTypedVal(), MTDuaColon(), MTMultiTyped(),
+# ]
 
 def mtMatcher():
     ''' case-tree of match-case cases. '''
-    # MTVal(), MTString(), MTRegexp(), MTList(), MTTuple(), MTDict(), MTStruct(), MTObjMember()
-    
-    # sqBrkLim = CaseOption(CaseBrkSquare(), [CaseListGen(), CaseBytes(), CaseListComprehension(), CaseList()])
-    # brkLim = CaseOption(CaseGenBrackets(), [sqBrkLim, CaseTuple(), CaseDictLine(), CaseBrackets()])
-
     
     wordLim = CaseOption(CaseWord(), [MT_Other(), MTVal()])
     brkLim = CaseOption(CaseGenBrackets(), [MTList(), MTTuple(), MTDict(), MTParenth(), ])
@@ -190,7 +125,6 @@ def mtMatcher():
 
     solidLim = CaseOption(CaseSolid(), [wordLim, strLim, solidRight, brkLim])
     
-    
     operLim = CaseOptionPrepared(CaseOperLim(), [MTPtGuard(), MTTypedVal(), MTMultiCase(), MTMultiTyped(), ])
     
     nonSolLim = CaseOption(NonSolid(), [MTDuaColon(), operLim, MTMultiTyped(),])
@@ -198,53 +132,55 @@ def mtMatcher():
     fullMatcher = CaseMatchcher([solidLim, nonSolLim])
     return fullMatcher
 
+
 # def getCases()->list[ExpCase]:
 #     return expCaseList
+
+
+# def mtCases(elems:list[Elem], cases: list[ExpCase], parent:ExpCase=None)->MatchingPattern:
+#     # print('mtCases', [repr(cc) for cc in cases])
+#     if isinstance(parent, (MTList)):
+#         cases = pMListInnerCases
+#     for mtCase in cases:
+#         # print('mtC>', mtCase)
+#         if mtCase.match(elems):
+#             # print('mt.found>', mtCase.__class__.__name__, '', elemStr(elems))
+#             if mtCase.hasSubExpr():
+#                 pattr, subElems = mtCase.split(elems)
+#                 subExp = elems2expr(subElems)
+#                 # print('$3>', subExp)
+#                 pattr = mtCase.setSub(pattr, subExp)
+#             else:
+#                 pattr = mtCase.expr(elems)
+#             return pattr
+#     return None
+
+
+
+# def makePMatchExpr(elems:list[Elem], parent:ExpCase=None)->MatchingPattern:
+#     # print('#makePMatchExpr:', [(n.text, Lt.name(n.type)) for n in elems])
+#     # print('\n#tree-makePMatchExpr/1::', ' '.join(["'%s'"%n.text for n in elems]))
+#     caseList = patternMatchCasesSolid
+#     ok, _ = isSolidExpr(elems, skipKeywords=True)
+#     if not ok:
+#         caseList = patternMatchCasesCplx
+        
+#     found = mtCases(elems, caseList, parent)
+#     if found:
+#         return found
+    
+#     # print('DEBUG: No current MTCase for `%s` ' % '~'.join([n.text for n in elems]))
+#     raise InterpretErr('No current MTCase for `%s` ' % ''.join([n.text for n in elems]))
+
+
+
+__mtMatcher = mtMatcher()
 
 
 def simpleExpr(expCase:ExpCase, elems)->Expression:
     # print('#simple-case:', expCase)
     return expCase.expr(elems)
 
-
-def mtCases(elems:list[Elem], cases: list[ExpCase], parent:ExpCase=None)->MatchingPattern:
-    # print('mtCases', [repr(cc) for cc in cases])
-    if isinstance(parent, (MTList)):
-        cases = pMListInnerCases
-    for mtCase in cases:
-        # print('mtC>', mtCase)
-        if mtCase.match(elems):
-            # print('mt.found>', mtCase.__class__.__name__, '', elemStr(elems))
-            if mtCase.hasSubExpr():
-                pattr, subElems = mtCase.split(elems)
-                subExp = elems2expr(subElems)
-                # print('$3>', subExp)
-                pattr = mtCase.setSub(pattr, subExp)
-            else:
-                pattr = mtCase.expr(elems)
-            return pattr
-    return None
-
-
-
-def makePMatchExpr(elems:list[Elem], parent:ExpCase=None)->MatchingPattern:
-    # print('#makePMatchExpr:', [(n.text, Lt.name(n.type)) for n in elems])
-    # print('\n#tree-makePMatchExpr/1::', ' '.join(["'%s'"%n.text for n in elems]))
-    caseList = patternMatchCasesSolid
-    ok, _ = isSolidExpr(elems, skipKeywords=True)
-    if not ok:
-        caseList = patternMatchCasesCplx
-        
-    found = mtCases(elems, caseList, parent)
-    if found:
-        return found
-    
-    # print('DEBUG: No current MTCase for `%s` ' % '~'.join([n.text for n in elems]))
-    raise InterpretErr('No current MTCase for `%s` ' % ''.join([n.text for n in elems]))
-
-
-
-__mtMatcher = mtMatcher()
 
 def complexExpr(expCase:SubCase, elems:list[Elem])->Expression:
     base, subs = expCase.split(elems)
@@ -330,7 +266,7 @@ def subBtContext(elems:list[Elem], blockContext:Expression):
     return None
 
 
-## py -m cProfile -s tottime -m unittest
+
 
 def caseMatcher():
     ''' case-tree of common cases '''


### PR DESCRIPTION
Profiling.
```
py -m cProfile -s tottime -m unittest
```
Prev.
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    22203    0.999    0.000    1.209    0.000 utils.py:124(mainOper)
  2323216    0.426    0.000    0.426    0.000 {built-in method builtins.isinstance}
1757845/1757587    0.285    0.000    0.285    0.000 {built-in method builtins.len}
    23918    0.263    0.000    0.505    0.000 parser.py:97(findOper)
26045/17833    0.240    0.000    1.124    0.000 oper_nodes.py:228(do)
   965427    0.236    0.000    0.236    0.000 {method 'startswith' of 'str' objects}
     6502    0.221    0.000    1.401    0.000 parser.py:175(splitLine)
    40193    0.219    0.000    0.485    0.000 utils.py:254(isSolidExpr)
```

Now
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     9732    0.495    0.000    0.599    0.000 utils.py:147(mainOper)
  2253295    0.415    0.000    0.415    0.000 {built-in method builtins.isinstance}
    24205    0.269    0.000    0.513    0.000 parser.py:99(findOper)
26045/17833    0.238    0.000    1.108    0.000 oper_nodes.py:228(do)
   977522    0.238    0.000    0.238    0.000 {method 'startswith' of 'str' objects}
     6645    0.226    0.000    1.334    0.000 parser.py:177(splitLine)
55502/31415    0.218    0.000    0.646    0.000 matcher.py:141(find)
1161012/1160752    0.189    0.000    0.189    0.000 {built-in method builtins.len}
    20125    0.180    0.000    0.605    0.000 inspect.py:2366(_signature_from_function)
    33287    0.138    0.000    0.275    0.000 utils.py:286(isSolidExpr)
```

Tests.
```

py -m unittest
...................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 307 tests in 2.393s

OK
```