### PR TITLE
Regexp - add type-constructor, fix var-type.

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -25,6 +25,7 @@ def initFuncs(ctx:Context):
     addTypeConstr(ctx, tuple_constr, TypeTuple())
     addTypeConstr(ctx, dict_constr, TypeDict())
     addTypeConstr(ctx, glif_constr, TypeGlif())
+    addTypeConstr(ctx, regexp_constr, TypeRegexp())
     
     # global funcs
     setNativeFunc(ctx, 'print', buit_print, TypeNull)

--- a/nodes/builtins.py
+++ b/nodes/builtins.py
@@ -30,7 +30,7 @@ def getVal(arg):
         v = t
     elif isinstance(v, (DictVal)):
         v = {k: getVal(vv) for k,vv in v.data.items()}
-    elif isinstance(v, (Function, FuncOverSet, ObjMethod)):
+    elif isinstance(v, (Function, FuncOverSet, ObjMethod, Regexp)):
         v = str(v)
     elif isinstance(v, Val):
         v = v.getVal()

--- a/nodes/iternodes.py
+++ b/nodes/iternodes.py
@@ -412,6 +412,7 @@ class LeftArrowExpr(BinOper):
             ltArg  = self.leftExpr.get()
         
         self.rightExpr.do(ctx) # make iter object
+        # print('Arr <- do3', self.leftExpr, '<-', self.rightExpr)
         rtArg = self.rightExpr.get()
 
         # print('Arr <-2 init ltArg', ltArg, ltArg.__class__)

--- a/nodes/oper_nodes.py
+++ b/nodes/oper_nodes.py
@@ -192,6 +192,7 @@ class OpAssign(AssignExpr):
                 fixType(dest, val)
                 
             dest.set(val)
+            # print('Op.assign11:', dest, val)
             
             if isinstance(dest, ObjectMember):
                 return
@@ -901,12 +902,12 @@ class RegexpMatchOper(RegexpOper):
         self.left.do(ctx)
         rx = self.left.get()
         if isinstance(rx, (Var)):
-            rx = rx.getVal()
+            rx = rx.get()
         self.right.do(ctx)
         src = self.right.get()
         src = var2val(src)
         res = rx.match(src)
-        self.res = Val(res, TypeBool())
+        self.res = Val(bool(res), TypeBool())
 
 
 class RegexpSearchOper(RegexpOper):

--- a/nodes/type_builtins.py
+++ b/nodes/type_builtins.py
@@ -13,6 +13,7 @@ from nodes.builtins import built_list, built_foldl, built_tostr
 
 import libs.str as libst
 import libs.bytes as lbytes
+import libs.regexp as rexp
 
 
 
@@ -71,6 +72,17 @@ def string_constr(ctx, arg:Val):
     if isinstance(arg.getType(), TypeGlif):
         arg = arg.get().val
     return built_tostr(ctx, arg)
+
+
+def regexp_constr(ctx, pattern:Val, flags:Val=None):
+    pval = pattern.getVal()
+    fval = ''
+    if flags:
+        fval = flags.getVal()
+    # print('$1', fval, flags)
+    ptr = rexp.compile(pval, rexp.str2flags(fval))
+    
+    return Regexp(ptr)
 
 
 def glif_constr(ctx, arg:Val):

--- a/readme.md
+++ b/readme.md
@@ -1012,6 +1012,8 @@ float(1) # 1.0
 bool(5) # true
 string(123) # '123'
 bytes('Hello!') # '0x[48 65 6c 6c 6f 21]'
+glif('A') # g'A'
+regexp('[a-z]+', 'iu') # regexp: re`[a-z]+`ui
 list('Cats') # ['C','a','t','s']
 tuple([1,2,3]) # (1,2,3)
 dict([('a',11), ('b',22)]) # {'a':11, 'b':22}
@@ -3167,8 +3169,16 @@ re`(group) (?:ignored group)` #// groups
 
 2. Flags.  
 `re`-syntax allows native [(pythons) regexp flags](https://docs.python.org/3/library/re.html#flags): `a,i,L,m,s,u,x`.  
-Flag or flags can be added to pattern right after pattern quotes without white spaces or separators.  
+
+Flag or flags can be added to the pattern right after pattern quotes, like a suffix, without white spaces or separators.  
 Flags set is corresponding to pythons flags of regexp.  
+- a - ASCII only for \w, \W, \b, \B, \d, \D, \s, \S = (?a)   
+- i - ignorecase = (?i)  
+- L - locale, not sure we need it for strings  
+- m - multiline = (?m)  
+- s - dotall, including `\n` = (?s)  
+- u - unicode (default case)  
+- x - verbose, igrored whitespaces, and endline comments `# smth` = (?x)  
 ```golang
 re`pattern`is
 re`pattern`aim
@@ -3180,6 +3190,27 @@ Just put variable on the flags position in the curly brackets (it looks similar 
 flags = 'muL'
 rx = re`pattern`{flags}
 ```
+3. Functional type-constructor is yet one way to make the regexp.  
+It has 2 args.  
+- pattern: string with regexp pattern  
+- flags: string with flags, optional  
+```golang
+rx1 = regexp('Hello, [a-z]+', 'ui')
+rx2 = regexp('Bye, [A-Z][a-z]+')
+```
+
+4. Regexp hat its own type `regexp`.  
+it can be applyed to variable or argument.  
+Also `regexp` type can be used for in type-check operator in conditional expressions or patter-matching.  
+```golang
+rx:regexp = re`Hello\S+`i
+
+if rx :: regexp /: #// code
+
+match rx
+    :: regexp /: #// code
+```
+
 
 Regexp objects have its own set of operators and can be used as a pattern of match-cases (in dev).
 

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -235,8 +235,10 @@ class TestDev(TestCase):
         
         TODO: check and optimize if need Function.checkTail process
         
-        TODO: add typing by regexp
+        DONE: add typing by regexp
         
+        TODO: add regexp construct
+            regexp(`[a-z]+`, 'ui')
         
         
     '''
@@ -248,47 +250,15 @@ res = []
 """
 
 
-
-    def _test_regexp_type(self):
-        '''
-        =~ operator
-        '''
-        code = r'''
-        res = []
-        
-        r1:regexp = re`\d+`
-        
-        res <- r1 =~ '123'
-        
-        
-        
-        # print('res = ', res)
-        '''
-        code = norm(code[1:])
-        tlines = splitLexems(code)
-        clines:CLine = elemStream(tlines)
-        ex = lex2tree(clines)
-        rCtx = rootContext()
-        ctx = rCtx.moduleContext()
-        ex.do(ctx)
-        rvar = ctx.get('res').get()
-        expv = []
-        self.assertEqual(expv, rvar.vals())
-
-    def _test_code3(self):
+    def _test_regexp_construct(self):
         ''' '''
         code = r'''
         
         res = []
         
-        x = 1
-        y = 0
-        if x > 5
-            res <- 2
-        else if x > 0
-            res <- 3
-        else
-            res <- 7
+        r1 = regexp('', '')
+        
+        r2 = regexp('')
         
         # print('res = ', res)
         '''

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -250,15 +250,27 @@ res = []
 """
 
 
-    def _test_regexp_construct(self):
+    def test_regexp_construct(self):
         ''' '''
         code = r'''
         
         res = []
         
-        r1 = regexp('', '')
+        # pattern and flags
+        r1 = regexp('[123]+', 'i')
         
-        r2 = regexp('')
+        res <- r1
+        res <- ('11', r1 =~ '11')
+        res <- ('23321', r1 =~ '23321')
+        res <- ('a1', r1 =~ 'a1')
+        
+        # default flags
+        pts = `[\-\=\+]`
+        r2:regexp = regexp(pts)
+        
+        res <- r2
+        res <- ('11-22-33', '11-22-33'.split(r2))
+        res <- ('11=22_44', '11=22_44'.split(r2))
         
         # print('res = ', res)
         '''
@@ -270,9 +282,11 @@ res = []
         # self.assertEqual(0, rvar.getVal())
         rvar = ctx.get('res').get()
         resv = resRepr(rvar.vals())
-        print(resv)
-        exv = []
-        # self.assertEqual(exv, resv)
+        # print(resv)
+        exv = [
+            're`[123]+`', ('11', True), ('23321', True), ('a1', False), 
+            're`[\\-\\=\\+]`', ('11-22-33', ['11', '22', '33']), ('11=22_44', ['11', '22_44'])]
+        self.assertEqual(exv, resv)
 
 
     def _test_code(self):

--- a/tests/test_regexp.py
+++ b/tests/test_regexp.py
@@ -26,6 +26,61 @@ class TestRegexp(TestCase):
     ''' Test builtin regexp lib. '''
 
 
+    def test_regexp_type(self):
+        '''
+        test fixes of type regexp
+        '''
+        code = r'''
+        res = []
+        
+        r1:regexp = re`\d+`
+        
+        res <- r1
+        
+        res <- r1 =~ '123'
+        
+        res <- r1 ?~ '12 as 34 ff gg 671'
+        
+        r2 = re`\s+`
+        res <- 'aa bb cc 44 5678 Hello! <!:?//>'.split(r2)
+        
+        res <- ('is regexp', r2 :: regexp)
+        res <- ('is string', r2 :: string)
+        
+        rmt = []
+        ss = [1, 'a', [], (1,2), {}, r1, r2, re`123`]
+        for n <- ss
+            match n
+                r :: regexp
+                    rmt <- ('re', r)
+                s :: string
+                    rmt <- ('s', s)
+                _
+                    rmt <- ('_', n)
+        
+        res <- rmt
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+        tlines = splitLexems(code)
+        clines:CLine = elemStream(tlines)
+        ex = lex2tree(clines)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        ex.do(ctx)
+        rvar = ctx.get('res').get()
+        resv = resRepr(rvar.vals())
+        # print(resv)
+        expv = [
+            're`\\d+`', True, 
+            [['12'], ['34'], ['671']], 
+            ['aa', 'bb', 'cc', '44', '5678', 'Hello!', '<!:?//>'], 
+            ('is regexp', True), ('is string', False), 
+            [('_', 1), ('s', 'a'), ('_', []), ('_', (1, 2)), ('_', {}), 
+             ('re', re.compile('\\d+')), ('re', re.compile('\\s+')), ('re', re.compile('123'))]]
+        self.assertEqual(expv, resv)
+
     def test_regexp_replace(self):
         ''' replace(src, rx, repl) '''
         code = r'''

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -95,17 +95,19 @@ def resRepr(src):
     from nodes.builtins import pstr
     rr = []
     for n in src:
-        # print('>>', n)
+        # print('>>', n, type(n))
         if isinstance(n, (list, tuple)):
             n = resRepr(n)
-        if isinstance(n, (bytearray2, bytearray, bytes)):
+        elif isinstance(n, (bytearray2, bytearray, bytes)):
             n = str(n)
-        if isinstance(n, (ObjectInstance)):
+        elif isinstance(n, (ObjectInstance)):
             n = 'st@%s' % str(n)
-        if isinstance(n, (Space)):
+        elif isinstance(n, (Space)):
             n = '%s' % str(n)
-        if isinstance(n, (Glif)):
+        elif isinstance(n, (Glif)):
             n = 'g(%s)'%(n.val)
+        elif isinstance(n, (Regexp)):
+            n = '%s'%str(n)
         rr.append(n)
     if isinstance(src, tuple):
         rr = tuple(rr)

--- a/vars.py
+++ b/vars.py
@@ -203,7 +203,7 @@ class ListVal(Collection):
     def vals(self):
         r = []
         for n in self.elems:
-            if isinstance(n, (FuncInst, ObjectInstance)):
+            if isinstance(n, (FuncInst, ObjectInstance, Regexp)):
                 r.append(n)
                 continue
             # print('$5', n)
@@ -504,6 +504,9 @@ class Regexp(Val):
             grval.extend(groups)
             rvals.append(ListVal(elems=[StringVal(s) for s in grval]))
         return ListVal(elems=rvals)
+
+    def __str__(self):
+        return 're`%s`' %(self.pattern.pattern)
 
 
 class EnumItem(Val):


### PR DESCRIPTION
Example:
```
pattern = `[a-f0-9]+`
flags = 'ui'
rx: regexp = regexp(pattern, flags)
rx =~ 'abCDef12340' # >> true
```
Tests:
```
py -m unittest
..........................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 314 tests in 2.384s

OK
```