### PR TITLE
Add multisource for arrow-assign operator in loop.

### DIFF
--- a/cases/control.py
+++ b/cases/control.py
@@ -95,40 +95,14 @@ class CaseMatchCase(SubCase):
         return base
 
 
-# class CaseMatchPattern(SubCase):
-#     '''
-#     left of `!-` operator.
-#     [*], {_:_}, (_,?), ...
-#     '''
-#     def __init__(self):
-#         super().__init__()
-#         self.splitter = OperSplitter()
-
-#     def match(self, elems:list[Elem]) -> bool:
-#         '''
-#         expr !- expr '''
-#         return False
-#         if len(elems) < 2:
-#             return False
-
-#         main = self.splitter.mainOper(elems)
-#         # dprint('CaseMatchCase elems[main]', elems[main].text, main)
-#         return isLex(elems[main], Lt.oper, '!-')
-
-#     def split(self, elems:list[Elem])-> tuple[Expression, list[list[Elem]]]:
-#         arrInd = self.splitter.mainOper(elems)
-#         exp = ArrOper()
-#         subs = [elems[:arrInd], elems[arrInd+1:]]
-#         return exp, subs
-
-#     def setSub(self, base:ArrOper, subs:list[Expression])->Expression:
-#         base.left = subs[0]
-#         if len(subs) > 1 and isinstance(subs[1], Expression):
-#             base.right = subs[1]
-
-
 class CaseFor(BlockCase, SubCase):
     ''' '''
+    
+    def __init__(self):
+        super().__init__()
+        self.brc = CaseBrackets()
+        self.cs = CaseSemic()
+    
     def match(self, elems:list[Elem]) -> bool:
         if elems[0].text == 'for':
             return True
@@ -136,9 +110,9 @@ class CaseFor(BlockCase, SubCase):
     def split(self, elems:list[Elem])-> tuple[Expression, list[list[Elem]]]:
 
         expSub = elems[1:]
-        if CaseBrackets().match(expSub):
+        if self.brc.match(expSub):
             expSub = expSub[1:-1]
-        _, subs = CaseSemic().split(expSub)
+        _, subs = self.cs.split(expSub)
 
         exp:LoopBlock = None
         match len(subs):
@@ -152,12 +126,12 @@ class CaseFor(BlockCase, SubCase):
     def setSub(self, base:LoopExpr, subs:Expression|list[Expression])->Expression:
         ''' nothing in minimal impl''' 
         slen = len(subs)
-        dprint('# CaseFor.setSub-', slen, subs)
+        # print('# CaseFor.setSub-', slen, subs)
         match slen:
             # iterator case
             case 1 if isinstance(base, LoopIterExpr):
                 base.setIter(subs[0])
-                # dprint('(=1)', subs[0] )
+                # print('For.case(=1)', subs[0] )
             # pre, cond
             case 2 if isinstance(base, LoopExpr): base.setExpr(pre=subs[0], cond=subs[1])
             # init, cond, post

--- a/nodes/expression.py
+++ b/nodes/expression.py
@@ -493,6 +493,7 @@ class SequenceExpr(Expression):
         for sub in self.subs:
             # dprint('SEQ getTuple:', sub)
             sub.do(ctx)
+            # print('Seq.getVals.sub=', sub, sub.get())
             res.append(sub.get())
         return res
 

--- a/nodes/iternodes.py
+++ b/nodes/iternodes.py
@@ -19,6 +19,12 @@ from nodes.datanodes import DictVal, ListVal, TupleVal
 class NIterator:
     ''' '''
     
+    def __init__(self):
+        self.vtype = TypeIterator()
+    
+    def getType(self):
+        return self.vtype
+    
     def start(self):
         ''' reset iterator to start position '''
         pass
@@ -60,18 +66,18 @@ class IterAssignExpr(Expression):
     def setSrc(self, exp:Expression):
         self.srcExpr = exp
 
-    def _start(self, ctx:Context):
-        self.srcExpr.do(ctx) # make iter object
-        iterSrc = self.srcExpr.get()
-        if isinstance(iterSrc, Var):
-            iterSrc = iterSrc.get() # extract collection from var
-        if isinstance(iterSrc, (ListVal, DictVal)):
-            self.itExp = SrcIterator(iterSrc)
-        elif isinstance(iterSrc.get(), (NIterator)):
-            self.itExp = iterSrc.get()
+    # def _start(self, ctx:Context):
+    #     self.srcExpr.do(ctx) # make iter object
+    #     iterSrc = self.srcExpr.get()
+    #     if isinstance(iterSrc, Var):
+    #         iterSrc = iterSrc.get() # extract collection from var
+    #     if isinstance(iterSrc, (ListVal, DictVal)):
+    #         self.itExp = SrcIterator(iterSrc)
+    #     elif isinstance(iterSrc.get(), (NIterator)):
+    #         self.itExp = iterSrc.get()
             
-        self.itExp.start()
-        self._first_iter = True
+    #     self.itExp.start()
+    #     self._first_iter = True
     
     def setIter(self, itExp:NIterator):
         # dprint('@# setIter', itExp)
@@ -111,15 +117,16 @@ class IterAssignExpr(Expression):
         # print('IterAssignExpr.do2 val=', val)
         valSet = []
         
-        if isinstance(val, (TupleVal, ListVal)):
-            valSet = val.elems
-        
         largLen = len(self.loopVars)
         
-        if largLen == 2 and isinstance(val, tuple):
-            # dict elem here, need to unpack
+        if isinstance(val, (TupleVal, ListVal)):
+            valSet = val.elems
+        elif isinstance(val, (list)):
+            # multi-source case
             valSet = val
-        elif largLen == 1:
+        
+        
+        if largLen == 1:
             if isinstance(val, tuple):
                 # dict elem, convert to TupleVal
                 valSet = TupleVal(elems=[n for n in val])
@@ -127,6 +134,12 @@ class IterAssignExpr(Expression):
                 # whole data into 1 var
                 valSet = val
             valSet = [valSet]
+        elif largLen == 2 and isinstance(val, tuple):
+            # dict elem here, need to unpack
+            valSet = val
+        # else:
+            # print('valSet', valSet)
+        
 
         vlen = len(valSet)
         # print('$1>>', vlen, valSet)
@@ -174,9 +187,17 @@ class IndexIterator(NIterator):
 
 
 class SrcIterator(NIterator):
-    ''' x <- [10,20,30] '''
-    def __init__(self, src:ListVal|DictVal|TupleVal):
+    ''' x <- [10,20,30] 
+        k, v <- {1:11, 2:22}
+        x, y, z <- [1, 2], [3,4], (5,6)
+    '''
+    
+    def __init__(self, src:ListVal|DictVal|TupleVal=None):
         self.src = None
+        self.iter = None
+        self.vtype = TypeIterator()
+        if not src:
+            return
         match src:
             case BytesVal():
                 self.src = src.val
@@ -184,27 +205,22 @@ class SrcIterator(NIterator):
                 self.src = src.elems
             case DictVal():
                 self.src = src.data
+            case _ if src:
+                self.src = src
         # print('SrcIterator.__init:', src, self.src)
         self._isDict = isinstance(src, DictVal)
-        # self.iterFunc = self._iterList
         self._keys = None
-        # if self._isDict:
-            # self.iterFunc = self._iterDict
-        self.iter = None
-        self.vtype = TypeIterator()
 
     def start(self):
         seq = self.src
-        # print('ITER / 1', self, seq)
+        # print('for n <- m / 1', self, seq)
         if self._isDict:
             seq = list(seq.keys())
             self._keys = seq
-            # self.iterFunc = self._iterDict
         self.iter = IndexIterator(0, len(seq))
 
     def step(self):
         self.iter.step()
-        # self.iterFunc()
 
     def hasNext(self):
         return self.iter.hasNext()
@@ -217,10 +233,50 @@ class SrcIterator(NIterator):
             # dprint('Iter-dict get: key, val', key, val)
             return (raw2val(key), val)
         val = self.src[key]
+        # print('IterSrc.get:', val)
         if isinstance(self.src, bytearray):
             val = Val(val, TypeInt())
         return val
 
+
+class MultiSrcIterator(SrcIterator):
+    
+    def __init__(self, src:list):
+        super().__init__(None)
+        self.sources:list[NIterator] = []
+        self.initSrc(src)
+        
+    def initSrc(self, srcSet:list):
+        for src in srcSet:
+            if not isinstance(src, NIterator):
+                # print('MSIt,init', src)
+                src = SrcIterator(src)
+            self.sources.append(src)
+    
+    def start(self):
+        ''''''
+        for srs in self.sources:
+            srs.start()
+        
+
+    def step(self):
+        for srs in self.sources:
+            srs.step()
+    
+    def hasNext(self):
+        ''' Iter count by 1-st sub-source '''
+        return self.sources[0].hasNext()
+
+
+    def get(self):
+        res = []
+        for srs in self.sources:
+            r = srs.get()
+            if isinstance(r, tuple):
+                res.extend(r)
+            else:
+                res.append(r)
+        return res
 
 
 class ListGenIterator(NIterator, SequenceGen):
@@ -397,6 +453,7 @@ class LeftArrowExpr(BinOper):
         # print('..')
         # print('Arr <- init1', self.leftExpr, '<-', self.rightExpr)
         ltArg = None
+        rtArg = None
         if isinstance(self.leftExpr, SequenceExpr):
             if self.leftExpr.getDelim() == ',':
                 # comma-separated sequence, can interpret as a tuple
@@ -413,16 +470,22 @@ class LeftArrowExpr(BinOper):
         
         self.rightExpr.do(ctx) # make iter object
         # print('Arr <- do3', self.leftExpr, '<-', self.rightExpr)
-        rtArg = self.rightExpr.get()
+        
+        if isinstance(self.rightExpr, SequenceExpr):
+            if self.rightExpr.getDelim() == ',':
+                rtArg = self.rightExpr.getVals(ctx)
+        else:
+            rtArg = self.rightExpr.get()
 
         # print('Arr <-2 init ltArg', ltArg, ltArg.__class__)
-        # print('Arr <-3 init rtArg:', rtArg)
+        # print(' <- init rtArg:', rtArg)
         if isinstance(ltArg, Var) and isinstance(ltArg.getType(), (TypeList, TypeDict, TypeBytes)):
             # print('Arr <-22 init ltArg', ltArg.getType())
             ltArg = var2val(ltArg)
             
         # print('Arr <-4 init ltArg', ltArg, ltArg.__class__)
-        # append case: ListVal/DictVal <- val
+        
+        # Found: append case: ListVal/DictVal <- val
         # if not isinstance(ltArg, list) and isinstance(ltArg, (ListVal, DictVal)):
         if isinstance(ltArg, (ListVal, DictVal, BytesVal)):
             if rtArg :
@@ -430,14 +493,31 @@ class LeftArrowExpr(BinOper):
             self.expr = Append(ltArg, rtArg)
             return
 
-        # next - iterator case
+        # Found: iterator case
+        rtSet = None
         if isinstance(rtArg, Var):
             rtArg = rtArg.get() # extract collection from var
+        elif isinstance(rtArg, list):
+            # multi-source
+            # print('rtArg:', rtArg)
+            rtSet = []
+            for rarg in rtArg:
+                # print('rarg:', rarg, rarg.get(), rarg.getType())
+                rarg = var2val(rarg)
+                if isinstance(rarg, (ListVal, TupleVal, DictVal)):
+                    ''
+                elif isinstance(rarg, Val):
+                    rarg = rarg.get()
+                rtSet.append(rarg)
+        
+        # print('rtSet', rtSet)
         # print('Arr <- init4 rtArg:', rtArg)
         # print('Arr <- init4 ltArg:', ltArg)
         itExp = None
         if isinstance(rtArg, (Collection, BytesVal)):
             itExp = SrcIterator(rtArg)
+        elif rtSet:
+            itExp = MultiSrcIterator(rtSet)
         elif isinstance(rtArg.get(), (NIterator)):
             itExp = rtArg.get()
         

--- a/readme.md
+++ b/readme.md
@@ -1918,11 +1918,11 @@ sliced = [x ; x <- src][2:5]
 
 ### 12.2 List comprehension / sequence generator
 Sequence generator (aka list comprehansion) is a shortened syntax (sugar) for making lists by another list or any sourec of sequence.  
-Basic syntax:  
+- Basic syntax:  
 ```python
 [elem; src-expr ;...]
 ```
-Expressions in the generator is divided by `;`.   
+- Expressions in the generator is divided by `;`.   
 Generator has such segments / expressions:  
 Second expression is a loop-iterator with arrow-assignment like `for` statement.  
 ```python
@@ -1931,7 +1931,7 @@ for x <- src
 # the same as
 [...; x <- src]
 ```
-First expression is an element of result.  
+- First expression is an element of result.  
 ```python
 res = []
 for x <- src
@@ -1940,7 +1940,7 @@ for x <- src
 # the same as
 res = [x; x <- src]
 ```
-Generator can have more expressions:
+- Generator can have more expressions:
 ```python
 [  
     elem-expr;       # 1) result element expression ;  
@@ -1951,7 +1951,7 @@ Generator can have more expressions:
 # 2-4 is a generator-block.  
 # 3-4 are optional  
 ```
-Generator should contain at least 2 segments:  
+- Generator should contain at least 2 segments:  
 ```python
 [n; n <- values]
 ```
@@ -1965,7 +1965,7 @@ src = [1..5]
 ]
 >> [101, 303, 505]
 ```
-Generator can have sub-iterations, ie 2-4 is a repeatable part, like:
+- Generator can have sub-iterations, ie 2-4 is a repeatable part, like:
 ```python
 arr1, arr2, arr3 # source lists
 [aa + bb + c ; 
@@ -1973,13 +1973,13 @@ arr1, arr2, arr3 # source lists
     b <- arr2; bb = b * b; 
     c <- arr3; c < 10 ]
 ```
-Next gen-blocks can use values from previous.
+- Next gen-blocks can use values from previous.
 ```python
 [x ; a <- [1..3] ; b <- [10,20]; c <-[400, 500]; 
     x = a + b + c; x % 7 == 0]
 >> [511, 413]
 ```
-Result-expr can see all values from all gen-blocks.
+- Result-expression can see all values from all gen-blocks.
 
 ```python
 # simple
@@ -2002,7 +2002,7 @@ src = [[x, y] ; x <- [5..7]; y <- [1..3]]
 # flatten source, make plane list
 nums = [ x ; sub <- src ; x <- sub]
 ```
-Too long expression can be formatted into multiple lines.
+- Too long expression can be formatted into multiple lines.
 ```python
 # generator: multi-expressions, multiline expression
 nums = [
@@ -2021,17 +2021,32 @@ nums = [
     a + b + c < 1000
 ]
 ```
-Now strings are not a valid native source for comprehansions. But it can be resolve by `tolist()` function.
+- Now strings are not a valid native source for comprehansions. But it can be resolve by `tolist()` function or `list()` constructor.
 ```python
 # list comprehension by converted string
 src = "ABCdef123"
 res = [s+'|'+s ; s <- tolist(src); !(s ?> '123')]
 ```
-
-Here just syntax joke :)  
-But it works, it returns list of lambdas which return generators.  
+- Multi-source expression in arrow-assigning is available here in the same way as in `for`-loop.  
 ```python
-[ x -> [x .. y] ; y <- [1 .. 10]]
+aa = [1,2,3]
+dd = {'a':'aa', 'b':'bb', 'c':'cc'}
+[ (a, k, v) ; a, k, v <- aa, dd ]
+```
+
+_Here just syntax joke :)_  
+```python
+c, d = 1, 5
+rr = [ a -> [a .. b] ; b <- [c .. d]]
+```
+But it works, it returns list of lambdas which return generator.  
+```python
+res = []
+for r <- rr
+    res <- [x; x <- r(0)]
+
+res # >>
+[[0, 1], [0, 1, 2], [0, 1, 2, 3], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4, 5]]
 ```
 
 ### 14. Builtin functions:  

--- a/readme.md
+++ b/readme.md
@@ -5,16 +5,16 @@ LISAPET is an object-oriented interpretable language with functional elements.
 Syntax is similar to mix of Python, Golang and some functional langs. It's written with python.  
 
 Name: Linear Interpreter of Scripting And Processing Expression Tree.  
-(LP, this code, miniscript)
-Alter name: FOTEX - Functional-object tree of expressions.
-possible ico: Fox pet on the bicycle
+(LP, this code, miniscript)  
+Alter name: FOTEX - Functional-object tree of expressions.  
+possible ico: Fox pet on the bicycle with headlight.  
 
 LP was started as a pet-project (and still is) - simple and small scripting language  (not so small already [facepalm]) for short scripts which could be run within the python project but without direct execution of native python code on the python interpreter (bad and unsafe way).  
 Instead of line-by-line execution, interpreter builds executable object, actually - tree of actions (expressions).  
 Than this object can be executed with some data. Once or many times, if needed.  
 Executable tree uses internal [Context](#12-execution-context)-container with working data (variables, values, types, etc).  
 Utility `run.py` can run LP code from file or string in console with the set of arguments (see [Usage](#usage) section).  
-Another way - call parser and interpreter manually from your code and run built object with context. It's the way to embed Lisapet into your own project (no examples here, see `run.py` and all tests in /`tests` dir).  
+Another way - call parser and interpreter manually from your code and run built object with context. It's the way to embed Lisapet into your own project.  
 
 --------------------------------------------------------
 --------------------------------------------------------
@@ -69,7 +69,8 @@ Content:
     1. [Classic `for` loop by counter](#6-while-for-statement)
     2. [`for i <- [1..5]`](#62-for-iterator-arrow-assign-operator--)
     3. [`for i <- iter(n)`](#63-function-iter)
-    4. [Keywords `continue`, `break`](#64-keywords-continue-break)
+    4. [`for a, b <- s1, s2` by multi-source](#64-multi-source-iterator-in-for-loop)
+    5. [Keywords `continue`, `break`](#65-keywords-continue-break)
 
 7. Functions:  
     1. [Definition and usage `func f()`](#7-function-definition-return)  
@@ -1173,6 +1174,7 @@ Left-arrow `<-` operator has several options.
 Here we use left-arrow as an iterative assignment in `for` statement.  
 It looks, like we pick the element from the sequence one-by-one.  
 - Iteration by `iter()` builtin function.  
+See details about `iter` [little later >>](#63-function-iter)
 ```python
 arr = [1,2,3]
 r = 0
@@ -1224,8 +1226,6 @@ for item <- dd
 ('b', 2)
 ```
 
-
-
 ### 6.3 Function `iter()`  
 Function `iter` can be used with several sets of arguments.  
 `iter(start, [last+1 [, step]])`  
@@ -1243,7 +1243,45 @@ iter(1, 5) # >> 1,2,3,4
 iter(1,7,2) # >> 1,3,5
 ```
 
-### 6.4 Keywords `continue`, `break`.  
+
+
+### 6.4 Multi-source iterator in `for`-loop.  
+`for` loop can iterate several sources (collection, iterator, generator) at the same time.  
+```python
+for a, b, c <- src1, src2, src3
+```
+In common case each source produce value for current iteration and assigning operator puts values into variables in the same order, like multiassign `=` does.  
+Count of elements (key : val pairs for `dict`) in all sources should be the same or at least first source should not be longer then any of other.  
+Dictionary produces key and value in this case.  
+Examples.  
+Collections:
+```python
+nums = [1,2,3]
+tt = (11, 22, 33)
+dd = {'a':'aa', 'b':'bb', 'c':'cc'}
+for a, b, k, v <- nums, tt, dd
+    print(a, b, k, v)
+```
+out:
+```
+1 11 a aa
+2 22 b bb
+3 33 c cc
+```
+Iterator or generators:
+```python
+for a, b, c <- iter(3), [21..23], [x * 5 ; x <- [1..3]]
+    print(a, b, c)
+```
+out:
+```
+0 21 5
+1 22 10
+2 23 15
+```
+
+
+### 6.5 Keywords `continue`, `break`.  
 Classic `break` and `continue`.  
 `continue` stops current iteration and goes to next.  
 `break` stops current iteration and whole loop.  
@@ -2790,18 +2828,23 @@ a, b, r1 = 4, 3, 0
 
 match a
     1  /: r1 = 100 # one-line case block
-    10 /: r1 = 200 # value-pattern
+    10 /: r1 = 200 # value-matching pattern
+
     # var-pattern (no check, just assign a to b)
-    x  /: c = x * 1000 
+    x  /: c = x * 1000 # starting cases sub-block
+        # sub-block continues on next line
         r1 = [c, x]
-    # sub-control
-    20
+    
+    20      # pattern
+        # sub-control
         if a > b
             r1 = 5
+    
+    # default case
     _  /: r1 = -2
 ```
 
-- In case, if `match` is a last expression in function or control-statement like `if` or `match`, last line in matched `case` is e resulting expression.  
+- In case, if `match` is a last expression in function or control-statement like `if` or `match`, last line in matched `case` is a resulting expression.  
 
 ```golang
 

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -50,12 +50,23 @@ class TestControl(TestCase):
             r2 <- (a, b)
         res <- r2
         
-        
         # iter-gen, list-get
         r3 = []
         for a, b <- [1..5], [x ; x <- [11..15]]
             r3 <- (a, b)
         res <- r3
+        
+        # function results
+        func foo(n)
+            [1 .. n]
+        
+        func bar(s, sep)
+            s.split(sep)
+        
+        r4 = []
+        for a, b <- foo(3), bar('aa, bb, cc,', ' ')
+            r4 <- (a, b)
+        res <- r4
         
         # print('res = ', res)
         '''
@@ -70,7 +81,8 @@ class TestControl(TestCase):
         exv = [
             [(101, 11), (102, 22), (103, 33), (104, 44)], 
             [(0, 21), (1, 22), (2, 23), (3, 24), (4, 25)], 
-            [(1, 11), (2, 12), (3, 13), (4, 14), (5, 15)]]
+            [(1, 11), (2, 12), (3, 13), (4, 14), (5, 15)],
+            [(1, 'aa,'), (2, 'bb,'), (3, 'cc,')]]
         self.assertEqual(exv, resv)
         
     def test_for_loop_multisource(self):

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -30,6 +30,131 @@ from tests.utils import *
 class TestControl(TestCase):
 
 
+    def test_for_multisource_gen(self):
+        ''' test fix for iter-gen and list-expression in for-loop '''
+        code = r'''
+        res = []
+        
+        
+        # iter-gen, list-expr
+        
+        r1 = []
+        # aa = [11,22,33,44]
+        for a, b <- [101..104], [11,22,33,44]
+            r1 <- (a,b)
+        res <- r1
+        
+        # index-gen, iter-gen
+        r2 = []
+        for a, b <- iter(5), [21..25]
+            r2 <- (a, b)
+        res <- r2
+        
+        
+        # iter-gen, list-get
+        r3 = []
+        for a, b <- [1..5], [x ; x <- [11..15]]
+            r3 <- (a, b)
+        res <- r3
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+        ex = tryParse(code)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        trydo(ex, ctx)
+        rvar = ctx.get('res').get()
+        resv = resRepr(rvar.vals())
+        # print(resv)
+        exv = [
+            [(101, 11), (102, 22), (103, 33), (104, 44)], 
+            [(0, 21), (1, 22), (2, 23), (3, 24), (4, 25)], 
+            [(1, 11), (2, 12), (3, 13), (4, 14), (5, 15)]]
+        self.assertEqual(exv, resv)
+        
+    def test_for_loop_multisource(self):
+        ''' Iterating by several collection sources.
+            for a, b, c <- s1, s2, s3  '''
+        code = r'''
+        res = []
+        
+        # 2 lists
+        nn = [1,2,3,4,5]
+        mm = [10, 20, 30, 40, 50]
+        
+        rr = []
+        for x, y <- nn, mm
+            rr <- (~'{x}+{y}', x + y)
+        res <- rr
+        
+        # 3 lists
+        
+        aa = [1,2,3]
+        bb = [4,5,6]
+        cc = [7,8,9]
+        r2 = []
+        for x, y, z <- aa, bb, cc
+            r2 <- (x, y, z)
+        res <- r2
+        
+        # 5 lists
+        a1 = [1,2,3,4]
+        a2 = [11,22,33,44]
+        a3 = [5,6,7,8]
+        a4 = [55,66,77,88]
+        a5 = [10, 20, 30, 40]
+        r3 = []
+        for q, w, e, r, t <- a1, a2, a3, a4, a5
+            r3 <- (q,w,e,r,t)
+        res <- r3
+        
+        # list, tuple
+        
+        aa = [1,2,3,4,5]
+        tt = ('a','b','c','d','e')
+        r4 = []
+        for a, t <- aa, tt
+            r4 <- (a, t)
+        res <- r4
+        
+        # list, dict
+        
+        aa = [1,2,3,4,5]
+        dd = {'a':'aaa', 'b':'bbb', 'c':'ccc', 'd':'ddd', 'e':'eee'}
+        r5 = []
+        for x, k, v <- aa, dd
+            r5 <- (x, k, v)
+        res <- r5
+        
+        # list, tuple, dict
+        aa = [1,2,3]
+        tt = ('A','B','C')
+        dd = {'aa':111, 'bb':222, 'cc':333}
+        r6 = []
+        for a, t, k, v <- aa, tt, dd
+            r6 <- (a, t, k, v)
+        res <- r6
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+        ex = tryParse(code)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        trydo(ex, ctx)
+        rvar = ctx.get('res').get()
+        resv = resRepr(rvar.vals())
+        # print(resv)
+        exv = [
+            [('1+10', 11), ('2+20', 22), ('3+30', 33), ('4+40', 44), ('5+50', 55)], 
+            [(1, 4, 7), (2, 5, 8), (3, 6, 9)], 
+            [(1, 11, 5, 55, 10), (2, 22, 6, 66, 20), (3, 33, 7, 77, 30), (4, 44, 8, 88, 40)], 
+            [(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')], 
+            [(1, 'a', 'aaa'), (2, 'b', 'bbb'), (3, 'c', 'ccc'), (4, 'd', 'ddd'), (5, 'e', 'eee')], 
+            [(1, 'A', 'aa', 111), (2, 'B', 'bb', 222), (3, 'C', 'cc', 333)]]
+        self.assertEqual(exv, resv)
+
     def test_match_result(self):
         ''' match-statement return result in the end of function '''
         code = r'''

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -186,7 +186,7 @@ class TestDev(TestCase):
         TODO: check and optimize if need Function.checkTail process
          
 
-        TODO: 21.1 Multi-reading in loop:
+        DONE: 21.1 Multi-reading in loop:
             put at right part one more collections, so assign more var in left: 
             aa = [1,2,3]
             dd = {11:1, 22:2, 33:3}
@@ -212,7 +212,6 @@ res = []
         ''' '''
         code = r'''
         res = []
-        
         
         # print('res = ', res)
         '''

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -65,11 +65,11 @@ class TestDev(TestCase):
                 _
                     50 # default result
 
-    # features for `enum` - not sure
-        TODO: Enum.name(11)
-        TODO: Enum.value(name)
-        TODO: Enum methods .names(), .values(), .items() > (name, val), .todict()
-        TODO: 22 ?> Enum # after methods
+        # (?) features for `enum` - not sure
+            TODO: Enum.name(11)
+            TODO: Enum.value(name)
+            TODO: Enum methods .names(), .values(), .items() > (name, val), .todict()
+            TODO: 22 ?> Enum # after methods
 
         TODO:? add shorten alias for the struct: stru A a:int
             shorten of string: name:strn
@@ -101,6 +101,18 @@ class TestDev(TestCase):
             func foo(a,b,c)...
             f = foo(1, 2); f(3) ;; g = foo(1); g(2, 3) # partial call
             f = foo~>(1)(2); f(3) ;; g = foo~>(1); g(2)(3)
+        
+        
+        TODO (?): put - inherit / include / mixin of a grup into an another grup
+            grup Auch
+                x = 1
+            
+            grup Boo
+                put Auch # copy and place here all things from Auch
+            
+            # not sure, maybe simple encapsulating will be enough:
+            grup Boo
+                au = Auch
         
         TODO: 
             think about escapes in triple-backticks strings
@@ -165,18 +177,6 @@ class TestDev(TestCase):
         
         TODO: add builtin compare() for base type: string, tuple, bytes.
         
-        
-        TODO (?): put - inherit / include / mixin of a grup into an another grup
-            # not sure, maybe simple encapsulating will be enough:
-            grup Auch
-                x = 1
-            
-            grup Boo
-                put Auch # copy and place here all things from Auch
-            
-            grup Boo
-                au = Auch
-        
 
         
         TODO: think about special type for methods. 
@@ -193,7 +193,11 @@ class TestDev(TestCase):
             for i, x, key, val <- iter(3), aa, dd
                 print(i, x, key, val)
         
+        TODO: 21.2 Mult-reading in list-gen:
+            [ x + y ; x, y <- nn, mm]
         
+        TODO: dict-gen
+            dict2 = { k: v + 10 ; k, v <- dict1; v > 0 && k != ''}
     '''
 
     _ = r"""
@@ -203,7 +207,7 @@ res = []
 """
 
 
-        
+    
     def _test_code(self):
         ''' '''
         code = r'''

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -157,8 +157,6 @@ class TestDev(TestCase):
         
         TODO: add assertion to cases in test_lists
         
-        TODO: bytes generator: 0x[(n << 2) % 0xff ; n <- iter(32)]
-        
         TODO: think about import native lib / module into LP code.
             eval.py: importLib('math', math)
             code.et: import python.math
@@ -193,8 +191,10 @@ class TestDev(TestCase):
             for i, x, key, val <- iter(3), aa, dd
                 print(i, x, key, val)
         
-        TODO: 21.2 Mult-reading in list-gen:
+        DONE: 21.2 Mult-reading in list-gen:
             [ x + y ; x, y <- nn, mm]
+        
+        TODO: bytes generator: 0x[(n << 2) % 0xff ; n <- iter(32)]
         
         TODO: dict-gen
             dict2 = { k: v + 10 ; k, v <- dict1; v > 0 && k != ''}
@@ -207,6 +207,7 @@ res = []
 """
 
 
+    
     
     def _test_code(self):
         ''' '''

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -20,6 +20,54 @@ class TestLists(TestCase):
     ''' Testing lists, iterators, generators, other collections '''
 
 
+    def test__listgen_with_multisource(self):
+        '''Multi-source in list-generator
+            [expr ; a, b, c <- s1, s2, s3 ] '''
+        code = r'''
+        res = []
+        
+        # list, tuple
+        aa = [1,2,3]
+        bb = [5,6,7]
+        tt = ('A', 'B', 'C')
+        r1 = []
+        r1 = [{c:(a,b)} ; a, b, c <- aa, bb, tt]
+        res <- r1
+        
+        # iter-gen, dict
+        dd = {'a':'aaa', 'b':'bbb', 'c':'ccc'}
+        r2 = [ ~'{a}:({k},{v})'; a, k, v <- [1 .. len(dd.keys()) ], dd ]
+        res <- r2
+        
+        # index-gen, slice
+        aa = [11, 22, 33, 44, 55, 66, 77]
+        r3 = [(i + 10, x) ; i, x <- iter(3), aa[1:4]]
+        res <- r3
+        
+        # strings
+        s1 = 'RGB'
+        s2 = 'red green blue'
+        r4 = [ ~'{b}:{c}' ; b, c <- list(s1), s2.split(' ') ]
+        res <- r4
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+        ex = tryParse(code)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        trydo(ex, ctx)
+        # self.assertEqual(0, rvar.getVal())
+        rvar = ctx.get('res').get()
+        resv = resRepr(rvar.vals())
+        # print(resv)
+        exv = [
+            [{'A': (1, 5)}, {'B': (2, 6)}, {'C': (3, 7)}], 
+            ['1:(a,aaa)', '2:(b,bbb)', '3:(c,ccc)'], 
+            [(10, 22), (11, 33), (12, 44)],
+            ['R:red', 'G:green', 'B:blue']]
+        self.assertEqual(exv, resv)
+
     def test_triple_dots_unpack_to_args(self):
         ''' '''
         code = r'''


### PR DESCRIPTION
Implement usage of several sources (right-operand) of left-arrow operator in loop-assigning expression.
1) Implement and test in `for`-loop.
2) test and fix in list-generator.
```
# for
for a, b, c <- src1, src2, src3
    use(a, b, c )
```
2) test and fix in list-generator.
```
r = [ a + b ; a, b <- src1, src2]
```
3) Test and fix usage all types of source: tuple, dict (key, value), iter(), [1 .. n], [x, x<-src], nums[1 : n].
```
nn = [1,2,3,4,5]
for a,b,c,d  <- [1,2,3], nn[1:3], [1..3], iter(3)
    use(a,b,c,d)
```
tests:
```
py -m unittest
................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 320 tests in 2.345s

OK
```