### PR TITLE
iter with negative step, fixes.

### DIFF
--- a/nodes/builtins.py
+++ b/nodes/builtins.py
@@ -20,7 +20,9 @@ def loop_iter(_, *args):
 
 def getVal(arg):
     v = arg
-    # print('getVal:', v)
+    # if not isinstance(v, Base):
+    #     return v
+    # print('getVal:', v, v.getType())
     if isinstance(arg, Var):
         v = arg.get()
     if isinstance(v, (ListVal, TupleVal)):
@@ -138,6 +140,14 @@ def buit_print(ctx:Context,*args):
             pargs.append(str(n))
             continue
         # print('$1 ', n)
+        v = n
+        if isinstance(v, Val):
+            if isinstance(v.getType(), TypeIterator):
+                v = v.getVal()
+            if isinstance(v, ListGenIterator):
+                # print('$1', arg, v)
+                v = v.allVals()
+            n = v
         v = getVal(n)
         # print('$2 ', v)
         if isinstance(v, (list)):

--- a/nodes/control.py
+++ b/nodes/control.py
@@ -183,6 +183,7 @@ class MatchExpr(MatchNode):
 
     def doCases(self, ctx:Context):
         self.lastCase = None
+        self.lastVal = None
         mval = self.match.get()
         vv = mval
         mval = var2val(mval)
@@ -201,6 +202,8 @@ class MatchExpr(MatchNode):
     def get(self):
         if not self.lastCase:
             return None
+        if self.lastVal:
+            return self.lastVal
         return self.lastCase.block.subs[-1].get()
 
 

--- a/nodes/expression.py
+++ b/nodes/expression.py
@@ -236,6 +236,7 @@ class Block(Expression):
             lastInd = i
             # lineRes = None
             lineRes = expr.get()
+            # print(' - return::', expr, lineRes)
             if isinstance(lineRes, FuncRes):
                 # print(' - return::', expr, lineRes)
                 self.lastVal = lineRes

--- a/nodes/iternodes.py
+++ b/nodes/iternodes.py
@@ -160,7 +160,7 @@ class IterAssignExpr(Expression):
 class IndexIterator(NIterator):
     ''' x <- iter(0, 10, 2)'''
     def __init__(self, a, b=None, c=None):
-        # print('IndexIterator:', self, 'a=', a, 'b=', b, 'c=', c)
+        # print('IndexIterator:',  'a=', a, 'b=', b, 'c=', c)
         # raise DebugExpr('')
         if c is None:
             c = 1
@@ -168,11 +168,14 @@ class IndexIterator(NIterator):
             b = a
             a = 0
         self.first = a
-        self.last = b # not last, but next after last
         self.__step = c
         self.index = a
+        self.k = 1
+        if self.__step < 0:
+            self.k = -1
+        self.last = b * self.k # not last, but next to last, depending of step
         self.vtype = TypeIterator()
-    
+
     def start(self):
         self.index = self.first
 
@@ -180,7 +183,12 @@ class IndexIterator(NIterator):
         self.index += self.__step
 
     def hasNext(self):
-        return self.index < self.last
+        # cur = self.index
+        # fin = self.last
+        # df = fin - cur
+        # k = 1 if self.__step > 0 else -1
+        # print('>', df, k, self.__step)
+        return self.index * self.k < self.last
 
     def get(self):
         return Val(self.index, TypeInt())

--- a/nodes/iternodes.py
+++ b/nodes/iternodes.py
@@ -342,14 +342,19 @@ class ListGenIterator(NIterator, SequenceGen):
                 break
         return res
     
-    def allVals(self):
-        res = ListVal()
+    def makeElems(self):
+        ''' method for internal usage, avoid to make unnecessary ListVal '''
+        res = []
         self.start()
         # print('LGI1 (%d, %d)' % (self.first, self.last))
         while(self.hasNext()):
-            res.addVal(self.get())
-            # print('LGI>>', res.vals())
+            res.append(self.get())
             self.step()
+        return res
+    
+    def allVals(self):
+        elems = self.makeElems()
+        res = ListVal(elems = elems)
         return res
 
 

--- a/nodes/iternodes.py
+++ b/nodes/iternodes.py
@@ -321,10 +321,13 @@ class ListGenIterator(NIterator, SequenceGen):
     def get(self):
         return Val(self.val, TypeInt())
     
+    def len(self):
+        return int(abs(self.last - self.first) / abs(self.__step)) + 1
+    
     def getSlice(self, start, end):
         res = ListVal()
         self.start()
-        xlen = int(abs(self.last - self.first) / abs(self.__step)) + 1
+        xlen = self.len()
         if start < 0:
             start = xlen + start
         if end < 0:

--- a/nodes/type_builtins.py
+++ b/nodes/type_builtins.py
@@ -132,6 +132,7 @@ def copyElems(src:list):
 
 
 def val2Seq(val:Val):
+    # print('$1', val, val.getType())
     r = []
     match val.getType():
         case TypeInt():
@@ -144,11 +145,14 @@ def val2Seq(val:Val):
             r = copyElems(val.elems)
         case TypeList():
             r = copyElems(val.elems)
+        case TypeIterator():
+            r = val.getVal().makeElems()
     return r
 
 
 def list_constr(ctx, arg:Val):
     r = val2Seq(arg)
+    # print('$2', r,)
     return ListVal(elems = r)
 
 

--- a/readme.md
+++ b/readme.md
@@ -1273,10 +1273,11 @@ for item <- dd
 
 ### 6.3 Function `iter()`  
 Function `iter` can be used with several sets of arguments.  
-`iter(start, [last+1 [, step]])`  
 1 arg - means 1) count of numbers from `0`.  
-2 args - means 1) starting number, 2) number after last.  
+2 args - means 1) starting number, 2) limitation value.  
 3 args - means 1,2) like before, 3) step of counter.  
+`iter(start|count, [arg_last [, step]])`  
+For positive step - last element will be nearest value, less than arg_last.  
 ```python
 # One arg iter(last+1)
 iter(3) # >> 0,1,2
@@ -1286,6 +1287,11 @@ iter(1, 5) # >> 1,2,3,4
 
 # args
 iter(1,7,2) # >> 1,3,5
+```
+In case with 3 args `iter` can produce back numeric sequence with negative step.  
+Last element in this case is limited by 2-nd arg from lower.  
+```python
+iter(5, -2, -3) # >> [5, 2, -1]
 ```
 
 

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -180,12 +180,6 @@ class TestDev(TestCase):
         func foo()
             local k = 5
             @! k # delete local only
-            
-        TODO: think about pattern matching in comprehensions condition
-        
-        TODO: think about import native lib / module into LP code.
-            eval.py: importLib('math', math)
-            code.et: import python.math
         
         TODO: interactive mode:
             $ py lisapet
@@ -194,36 +188,142 @@ class TestDev(TestCase):
             interpret after and of current top-block
             navigate through code, edit mode (looks like vim)
             # sol_1: python idlelib ?
-            
-        BUG: py -m run -c "print([1..5][:])"
-            Error handling:  'ListGenIterator' object has no attribute 'len'
         
-        TODO: fix iter() for down-iteration and negative step
+        DONE: fix iter() for down-iteration and negative step
+            
+        TODO: think about pattern matching in comprehensions condition
         
-        TODO: add function as generator (like yeald in py)
+        TODO: think about import native lib / module into LP code.
+            eval.py: importLib('math', math)
+            code.et: import python.math
+        
+        TODO: add function / (like yeald in py)
+            func foo(x)
+                for i <- iter(x)
+                    res = i * 2
             
-            struct Generator cur: int
+            for n <- foo(5)
+                n # ...
+        
+        TODO: method / object as a generator 
             
-            struct Gen(Generator)
+            struct Generator
+            func Generator init()
+            func Generator get()
+            func Generator next()
+            # **
+            struct IntGen(Generator) value:int, start:int, fin:int, diff:int 
+            func IntGen(x)
+                IntGen{start:0, fin:x, diff:1}
+            func IntGen(s, f)
+                IntGen{start:s, fin:f, diff:1}
+            func IntGen(s, f, d)
+                IntGen{start:s, fin:f, diff:d}
             
-            func gen:Gen next(x)
-                gen.cur += -1
-                
-            func gen:Gen get()
-                gen.cur
+            func g:Generator init()
+                g.value = g.start
+            func g:Generator get()
+                g.value
+            func g:Generator next()
+                g.value += g.diff
+                g.value < g.fin # hasNext (?)
             
+            # ***
+            struct Gen(Generator) fin:int
+            
+            # func gen:Gen get()
+            #     gen.value
+            
+            func gen:Gen next()
+                if gen.value >= gen.fin
+                    gen.stop()
+                gen.value += -1
+            
+            # ***
             gg = Gen(5)
             for n <- gg
                 n # 0 1 2 3 4 
+            
+            TODO?: yield gen
+                func f()
+                    for n <- [1..5]
+                        yield n
+            
+            TODO?: yield compr gen
+                ( n ; n <- [1..5] ) # generator, not a tuple comprehension 
+                [yield n ; n <- [1..5]] 
+                [: n ; n <- [1..5]] 
+                Looks like (;;) is enough
+        
+        TODO: range syntax (haskell like)
+            lazy producer of numeric sequence
+            [begin .. end] # already done
+            [2, 1..5] [step, begin .. end]
+            [-1, 5 .. 1] # check after positive custom step
+        
+        BUG: py -m run -c "print([1..5][:])"
+            Error handling:  'ListGenIterator' object has no attribute 'len'
+            TODO: add constructor list([1..5])
+        
+            TODO: add implicit conversion [..] to list before slice
     '''
 
     _ = r"""
 # guides
-res = []
+
 
 """
 
 
+
+    
+    def _test_code_slice_iter_gen(self):
+        ''' '''
+        code = r'''
+        res = []
+        
+        ss1 = [1..9]
+        res <- ss1[2:7]
+        
+        res <- [11..19][2:7]
+
+        # res <- [11..19][:]
+        res <- list([11..19])
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+        ex = tryParse(code)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        trydo(ex, ctx)
+        # self.assertEqual(0, rvar.getVal())
+        rvar = ctx.get('res').get()
+        resv = resRepr(rvar.vals())
+        print(resv)
+        exv = []
+        # self.assertEqual(exv, resv)
+    
+    def test_list_constr_by_num_gen(self):
+        ''' '''
+        code = r'''
+        res = []
+        
+        res <- list([11..19])
+        res <- list([21..29])[:]
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+        ex = tryParse(code)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        trydo(ex, ctx)
+        rvar = ctx.get('res').get()
+        resv = resRepr(rvar.vals())
+        # print(resv)
+        exv = [[11, 12, 13, 14, 15, 16, 17, 18, 19], [21, 22, 23, 24, 25, 26, 27, 28, 29]]
+        self.assertEqual(exv, resv)
 
     
     def _test_code(self):
@@ -231,10 +331,8 @@ res = []
         code = r'''
         res = []
         
-        r = []
-        for n <- iter(10, 5, -1)
-            r <- n
-        print(r)
+        ss1 = [1..9]
+        res <- ss1[2:7]
         
         # print('res = ', res)
         '''

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -40,30 +40,6 @@ class TestDev(TestCase):
         
         
         
-         
-        DONE: const value
-            const x: int = 10
-        
-        DONE: if conditional expr is a last node of function then
-            last executed expression (sub-part of conditional) should be a result of function
-        func foo()
-            if cond
-                ...
-                expr1 # result
-            else if cond
-                expr2 # result
-            else
-                expr3 # result
-        func foo()
-            match n
-                1 /: 10 # result
-                2
-                    20 # result
-                a :: type
-                    b = f(a)
-                    b + 30 # result
-                _
-                    50 # default result
 
         # (?) features for `enum` - not sure
             TODO: Enum.name(11)
@@ -103,6 +79,18 @@ class TestDev(TestCase):
             f = foo(1, 2); f(3) ;; g = foo(1); g(2, 3) # partial call
             f = foo~>(1)(2); f(3) ;; g = foo~>(1); g(2)(3)
         
+        TODO:? var type in for-loop 
+            for n:int <- nn
+        
+        TODO: (?) think about ?> for bytes, not sure
+
+        TODO: nop. think about type casting by colon; type in left
+            x:int = int: true
+            # type-constructor is enough 
+        
+        TODO (?): to think: change const from left-modifier to right-operand of `:`
+            var : const = val # const elem
+            var : const(int) = val # strict typed const elem
         
         TODO (?): put - inherit / include / mixin of a grup into an another grup
             grup Auch
@@ -114,20 +102,6 @@ class TestDev(TestCase):
             # not sure, maybe simple encapsulating will be enough:
             grup Boo
                 au = Auch
-        
-        TODO: 
-            think about escapes in triple-backticks strings
-            unary backtick tested in test_parsing_string_backtiks
-            mres = ``` \\n \\t \\ \\s \\w ```
-        
-        TODO: type() for user defined types
-            struct ABC a: int, b: int
-            abc = ABC{a:1, b:2}
-            res <- type(abc)
-        
-        TODO: inspect and resolve MatchPtrCase to avoid use tree.raw2done if not needed anymore
-        
-        TODO: check type of operand for all operators
         
         TODO: overload: 
             test overloading for imported functions, 
@@ -146,26 +120,39 @@ class TestDev(TestCase):
         
         TODO: error of composition of functions with more than 1 arg
         
+        TODO: 
+            think about escapes in triple-backticks strings
+            unary backtick tested in test_parsing_string_backtiks
+            mres = ``` \\n \\t \\ \\s \\w ```
+        
+        TODO: type() for user defined types
+            struct ABC a: int, b: int
+            abc = ABC{a:1, b:2}
+            res <- type(abc)
+        
+        TODO: check type of operand for all operators
+        
+        TODO: inspect and resolve MatchPtrCase to avoid use tree.raw2done if not needed anymore
+        
+        TODO: think about special type for methods. 
+            It can simplify check of tail recursion for case with similar names
+            maybe )
+        
         TODO: tail recursion:
         1) tail optimization by func name, during interpretation (before add to ctx)
         2) extend tail-recur case for earlier returns - not sure 
         
-        TODO:? var type in for-loop 
-            for n:int <- nn
-
-        TODO: nop. think about type casting by colon; type in left
-            x:int = int: true
-            # type-constructor is enough 
+        TODO: check and optimize if need Function.checkTail process
         
-        TODO (?): to think: change const from left-modifier to right-operand of `:`
-            var : const = val # const elem
-            var : const(int) = val # strict typed const elem
+        TODO: bytes.replace({old:new,...}) # replace by table in dict, overloading replace
+        
+        TODO: add builtin compare() for base type: string, tuple, bytes.
+        
+        TODO: string.replace({dict}) # check, implement if not
+        
+        TODO: fix print(bool): should be false, true, instead of False, True
         
         TODO: add assertion to cases in test_lists
-        
-        TODO: think about import native lib / module into LP code.
-            eval.py: importLib('math', math)
-            code.et: import python.math
         
         TODO: math functions:
             log(x, base), ln(x), lg(x),
@@ -173,70 +160,8 @@ class TestDev(TestCase):
             sin(), cos(), tg(), ctg(), atg(), actg(), asin(), acos(),...
             ceil(), floor(), round()
         
-        TODO: bytes.replace({old:new,...}) # replace by table in dict, overloading replace
-        
-        TODO: string.replace({dict}) # check, implement if not
-        
-        TODO: fix print(bool): should be false, true, instead of False, True
-        
-        TODO: add builtin compare() for base type: string, tuple, bytes.
-        
-        
-        TODO: think about special type for methods. 
-            It can simplify check of tail recursion for case with similar names
-            maybe )
-        
-        TODO: check and optimize if need Function.checkTail process
-         
-        DONE: 21.1 Multi-reading in loop:
-            put at right part one more collections, so assign more var in left: 
-            aa = [1,2,3]
-            dd = {11:1, 22:2, 33:3}
-            for i, x, key, val <- iter(3), aa, dd
-                print(i, x, key, val)
-        
-        DONE: 21.2 Mult-reading in list-gen:
-            [ x + y ; x, y <- nn, mm]
-        
-        DONE: deprecate list/dict <- append operator inside of comprehension
-        
-        DONE: dict-gen
-            dict2 = { k: v + 10 ; k, v <- dict1; v > 0 && k != ''}
-        
-        DONE: bytes generator: 0x[(n << 2) % 0xff ; n <- iter(32)]
-        
-        DONE: match-case: assign val in pattern
-            var @ [1, 2, v2 @ _] /: print(var, v2)
-            `x @ _` the same as simple var-pattern `x` that matches any single value
-        
-        FIXED: if we have predefined list / dict and try to use same name in the iterative assign by `<-` it breaks code
-            File "C:\Users\admin\Documents\python_examples\minilang\nodes\oper_nodes.py", line 68, in doRight
-                src.do(ctx)
-            File "C:\Users\admin\Documents\python_examples\minilang\nodes\iternodes.py", line 652, in do
-                self.iterLoop(0, ctx)
-            File "C:\Users\admin\Documents\python_examples\minilang\nodes\iternodes.py", line 623, in iterLoop
-                inod.start()
-            == solution: deprecate use list <- val in the generators.
-            == solution: add alter operator instead of universal <- .
-            == solution: deprecate <- for append elem in generator, 
-                add alter oper for explicit append action: << <-- 
-        
-        DONE: think about deletion of var by name
-            @! operator has been implemented
-            # delete(x); del(x)
-            # --- x ; -/- x ; -= x ; >< x ;
-            # @delete x; @del x
-            # del x, y, name # non-single expr
-            # @del(x, y, name) # single expr
-        
-        TODO (?): add explicit append operator: list << val, dict << val. to use into comprehensions  
+        TODO (?): explicit append operator: list << val, dict << val. to use into comprehensions  
             alters:   <:  <=  <--  <<  
-            
-        TODO: think about pattern matching in comprehensions condition
-        
-        TODO: interactive mode:
-            $ py lisapet
-            >> code...
         
         TODO: outer value: var/const/regexp in pattern matching:
             name = 'Vasya'
@@ -255,15 +180,41 @@ class TestDev(TestCase):
         func foo()
             local k = 5
             @! k # delete local only
+            
+        TODO: think about pattern matching in comprehensions condition
         
-        TODO: think about ?> for bytes
+        TODO: think about import native lib / module into LP code.
+            eval.py: importLib('math', math)
+            code.et: import python.math
         
-        DONE: ~[s, s <- "..."] gen by string: 
-            solution (1) `~` operator as a list-to-string convertor
-            sol(2): ~[;] # string-generator 
-            s <- "..." # glif stream from string
-            ~[gX ; gX <- string] # join all glifs to string
-            [ gX ; gX <- string ] # list of glifs
+        TODO: interactive mode:
+            $ py lisapet
+            >> code...
+            remember indent, backspace by indent size
+            interpret after and of current top-block
+            navigate through code, edit mode (looks like vim)
+            # sol_1: python idlelib ?
+            
+        BUG: py -m run -c "print([1..5][:])"
+            Error handling:  'ListGenIterator' object has no attribute 'len'
+        
+        TODO: fix iter() for down-iteration and negative step
+        
+        TODO: add function as generator (like yeald in py)
+            
+            struct Generator cur: int
+            
+            struct Gen(Generator)
+            
+            func gen:Gen next(x)
+                gen.cur += -1
+                
+            func gen:Gen get()
+                gen.cur
+            
+            gg = Gen(5)
+            for n <- gg
+                n # 0 1 2 3 4 
     '''
 
     _ = r"""
@@ -273,13 +224,17 @@ res = []
 """
 
 
-    
 
     
     def _test_code(self):
         ''' '''
         code = r'''
         res = []
+        
+        r = []
+        for n <- iter(10, 5, -1)
+            r <- n
+        print(r)
         
         # print('res = ', res)
         '''

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -190,6 +190,11 @@ class TestDev(TestCase):
             # sol_1: python idlelib ?
         
         DONE: fix iter() for down-iteration and negative step
+        
+        DONE: py -m run -c "print([1..5][:])"
+            Error handling:  'ListGenIterator' object has no attribute 'len'
+            DONE: add constructor list([1..5])
+            DONE: add implicit conversion [..] to list before slice
             
         TODO: think about pattern matching in comprehensions condition
         
@@ -261,11 +266,15 @@ class TestDev(TestCase):
             [2, 1..5] [step, begin .. end]
             [-1, 5 .. 1] # check after positive custom step
         
-        BUG: py -m run -c "print([1..5][:])"
-            Error handling:  'ListGenIterator' object has no attribute 'len'
-            TODO: add constructor list([1..5])
+        TODO: add (;;) lazy generator of sequence, 
+            can be used in loop, comprehention, sequence constructor
+            for n <- (x ; x <- nums ; x > 2)
+            list(((x ; x <- nums ; x > 2))) # think about skippng internal brackets
+            gen = (x ; x <- nums ; x > 2)
+            [n * 10 ; n <- gen]
         
-            TODO: add implicit conversion [..] to list before slice
+        TODO: split comprehensions (should return collection/sequence)
+                and generator (return iterative object)
     '''
 
     _ = r"""
@@ -277,54 +286,6 @@ class TestDev(TestCase):
 
 
     
-    def _test_code_slice_iter_gen(self):
-        ''' '''
-        code = r'''
-        res = []
-        
-        ss1 = [1..9]
-        res <- ss1[2:7]
-        
-        res <- [11..19][2:7]
-
-        # res <- [11..19][:]
-        res <- list([11..19])
-        
-        # print('res = ', res)
-        '''
-        code = norm(code[1:])
-        ex = tryParse(code)
-        rCtx = rootContext()
-        ctx = rCtx.moduleContext()
-        trydo(ex, ctx)
-        # self.assertEqual(0, rvar.getVal())
-        rvar = ctx.get('res').get()
-        resv = resRepr(rvar.vals())
-        print(resv)
-        exv = []
-        # self.assertEqual(exv, resv)
-    
-    def test_list_constr_by_num_gen(self):
-        ''' '''
-        code = r'''
-        res = []
-        
-        res <- list([11..19])
-        res <- list([21..29])[:]
-        
-        # print('res = ', res)
-        '''
-        code = norm(code[1:])
-        ex = tryParse(code)
-        rCtx = rootContext()
-        ctx = rCtx.moduleContext()
-        trydo(ex, ctx)
-        rvar = ctx.get('res').get()
-        resv = resRepr(rvar.vals())
-        # print(resv)
-        exv = [[11, 12, 13, 14, 15, 16, 17, 18, 19], [21, 22, 23, 24, 25, 26, 27, 28, 29]]
-        self.assertEqual(exv, resv)
-
     
     def _test_code(self):
         ''' '''

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -311,58 +311,6 @@ class TestDev(TestCase):
         
 
 
-    def _test_match_last_expr_of_case_as_result(self):
-        ''' if `match` is a last expression in function. 
-            each sub-case of match will return result of their last expression'''
-        code = r'''
-        res = []
-        
-        func fsubRes(n)
-            # Last expression is a result
-            match n
-                # indent block
-                ::int # some comment
-                    x  = 1
-                    x
-                
-                # inline block
-                ::bool /: x = 2; x
-                
-                # /: but indent (it's ok)
-                {_:_} /:
-                    y = 3
-                    y
-                
-                # block with sub control
-                p::(tuple|list)
-                    r4 = []
-                    for x <- p
-                        r4 <- x
-                        if len(r4) >= 3
-                        # in if/else must use `return`
-                            return (4, r4, p)
-                    -1000
-                # default
-                _ /: 5
-            # end of function
-            
-        nn = [1, true, [1,2,3], (3,4,5), {4:44}, 1.5, [100,200]]
-        
-        for k <- nn
-            res <- fbase(k)
-            
-        # print('res = ', res)
-        '''
-        code = norm(code[1:])
-        ex = tryParse(code)
-        rCtx = rootContext()
-        ctx = rCtx.moduleContext()
-        trydo(ex, ctx)
-        # self.assertEqual(0, rvar.getVal())
-        # rvar = ctx.get('res').get()
-        # exv = [1, 2, (4, [1, 2, 3], [1, 2, 3]), (4, [3, 4, 5], (3, 4, 5)), 3, 5, -2000]
-        # self.assertEqual(exv, rvar.vals())
-
 
     def _test_barr(self):
         ''' '''

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -27,6 +27,103 @@ class TestIter(TestCase):
 
 
     
+    
+    def test_iter_negative(self):
+        '''back iter with negative step '''
+        code = r'''
+        res = []
+        
+        r = []
+        for n <- iter(2,8,2)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(5)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(10, 5, -1)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(5, 0, -1)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(5, -1, -1)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(6, -2, -2)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(6, -5, -2)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(5, -2, -3)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(0, 101, 25)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(100, -1, -25)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(-2, -11, -4)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(2**30, 2 **30+5, 1)
+            r <- n
+        res <- (r)
+        
+        r = []
+        for n <- iter(-1000000, -1000005, -1)
+            r <- n
+        res <- (r)
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+        ex = tryParse(code)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        trydo(ex, ctx)
+        rvar = ctx.get('res').get()
+        resv = resRepr(rvar.vals())
+        # print(resv)
+        exv = [
+            [2, 4, 6], 
+            [0, 1, 2, 3, 4], 
+            [10, 9, 8, 7, 6], 
+            [5, 4, 3, 2, 1], 
+            [5, 4, 3, 2, 1, 0], 
+            [6, 4, 2, 0], 
+            [6, 4, 2, 0, -2, -4], 
+            [5, 2, -1], 
+            [0, 25, 50, 75, 100], 
+            [100, 75, 50, 25, 0], 
+            [-2, -6, -10],
+            [1073741824, 1073741825, 1073741826, 1073741827, 1073741828],
+            [-1000000, -1000001, -1000002, -1000003, -1000004]]
+        self.assertEqual(exv, resv)
+
     def test_string_comprehension(self):
         ''' '''
         code = r'''

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -26,8 +26,43 @@ class TestIter(TestCase):
     ''' iteration cases '''
 
 
-    
-    
+    def test_slice_iter_gen(self):
+        ''' '''
+        code = r'''
+        res = []
+        
+        ss1 = [1..9]
+        res <- ss1[2:7]
+        
+        res <- [11..19][2:7]
+
+        res <- [11..19][:]
+        
+        func nns(a, b)
+            return [a..b]
+        
+        res <- nns(3, 8)[1:-1]
+        res <- nns(5,10)[:]
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+        ex = tryParse(code)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        trydo(ex, ctx)
+        # self.assertEqual(0, rvar.getVal())
+        rvar = ctx.get('res').get()
+        resv = resRepr(rvar.vals())
+        # print(resv)
+        exv = [
+            [3, 4, 5, 6, 7], 
+            [13, 14, 15, 16, 17], 
+            [11, 12, 13, 14, 15, 16, 17, 18, 19], 
+            [4, 5, 6, 7], 
+            [5, 6, 7, 8, 9, 10]]
+        self.assertEqual(exv, resv)
+
     def test_iter_negative(self):
         '''back iter with negative step '''
         code = r'''

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -20,6 +20,27 @@ class TestLists(TestCase):
     ''' Testing lists, iterators, generators, other collections '''
 
 
+    def test_list_constr_by_num_gen(self):
+        ''' '''
+        code = r'''
+        res = []
+        
+        res <- list([11..19])
+        res <- list([21..29])[:]
+        
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+        ex = tryParse(code)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        trydo(ex, ctx)
+        rvar = ctx.get('res').get()
+        resv = resRepr(rvar.vals())
+        # print(resv)
+        exv = [[11, 12, 13, 14, 15, 16, 17, 18, 19], [21, 22, 23, 24, 25, 26, 27, 28, 29]]
+        self.assertEqual(exv, resv)
+
     def test_triple_dots_unpack_to_args(self):
         ''' '''
         code = r'''

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -30,6 +30,58 @@ class TestMatch(TestCase):
     ''' cases of `match` statement '''
 
 
+    def test_match__if_return_and_last_expr_result(self):
+        ''' `if-return` in the `match`'''
+        code = r'''
+        res = []
+        
+        func fsubRes(n)
+            # Last expression is a result
+            match n
+                # indent block
+                ::int # some comment
+                    x  = 1
+                    x
+                
+                # inline block
+                ::bool /: x = 2; x
+                
+                # /: but indent (it's ok)
+                {_:_} /:
+                    y = 3
+                    y
+                
+                # block with sub control
+                p::(tuple|list)
+                    r4 = []
+                    for x <- p
+                        r4 <- x
+                        if len(r4) >= 3
+                            return (4, r4, p)
+                    -1000
+                # default
+                _ /: 5
+            # end of function
+            
+        nn = [1, true, [1,2,3], (3,4,5), {4:44}, 1.5, [100,200]]
+        
+        for k <- nn
+            res <- fsubRes(k)
+            
+        # print('res = ', res)
+        '''
+        code = norm(code[1:])
+        ex = tryParse(code)
+        rCtx = rootContext()
+        ctx = rCtx.moduleContext()
+        trydo(ex, ctx)
+        # self.assertEqual(0, rvar.getVal())
+        rvar = ctx.get('res').get()
+        resv = resRepr(rvar.vals())
+        # print(resv)
+        exv = [1, 2, (4, [1, 2, 3], [1, 2, 3]), (4, [3, 4, 5], (3, 4, 5)), 3, 5, -1000]
+        self.assertEqual(exv, rvar.vals())
+
     def test_code_mtcase_at_assign(self):
         ''' '''
         code = r'''

--- a/todo.et
+++ b/todo.et
@@ -387,6 +387,78 @@ Fixes:
 # DONE
         
 
+         
+        DONE: 21.1 Multi-reading in loop:
+            put at right part one more collections, so assign more var in left: 
+            aa = [1,2,3]
+            dd = {11:1, 22:2, 33:3}
+            for i, x, key, val <- iter(3), aa, dd
+                print(i, x, key, val)
+        
+        DONE: 21.2 Mult-reading in list-gen:
+            [ x + y ; x, y <- nn, mm]
+        
+        DONE: deprecate list/dict <- append operator inside of comprehension
+        
+        DONE: dict-gen
+            dict2 = { k: v + 10 ; k, v <- dict1; v > 0 && k != ''}
+        
+        DONE: bytes generator: 0x[(n << 2) % 0xff ; n <- iter(32)]
+        
+        DONE: match-case: assign val in pattern
+            var @ [1, 2, v2 @ _] /: print(var, v2)
+            `x @ _` the same as simple var-pattern `x` that matches any single value
+        
+        FIXED: if we have predefined list / dict and try to use same name in the iterative assign by `<-` it breaks code
+            File "C:\Users\admin\Documents\python_examples\minilang\nodes\oper_nodes.py", line 68, in doRight
+                src.do(ctx)
+            File "C:\Users\admin\Documents\python_examples\minilang\nodes\iternodes.py", line 652, in do
+                self.iterLoop(0, ctx)
+            File "C:\Users\admin\Documents\python_examples\minilang\nodes\iternodes.py", line 623, in iterLoop
+                inod.start()
+            == solution: deprecate use list <- val in the generators.
+            == solution: add alter operator instead of universal <- .
+            == solution: deprecate <- for append elem in generator, 
+                add alter oper for explicit append action: << <-- 
+        
+        DONE: think about deletion of var by name
+            @! operator has been implemented
+            # delete(x); del(x)
+            # --- x ; -/- x ; -= x ; >< x ;
+            # @delete x; @del x
+            # del x, y, name # non-single expr
+            # @del(x, y, name) # single expr
+        
+        DONE: ~[s, s <- "..."] gen by string: 
+            solution (1) `~` operator as a list-to-string convertor
+            sol(2): ~[;] # string-generator 
+            s <- "..." # glif stream from string
+            ~[gX ; gX <- string] # join all glifs to string
+            [ gX ; gX <- string ] # list of glifs
+         
+        DONE: const value
+            const x: int = 10
+        
+        DONE: if conditional expr is a last node of function then
+            last executed expression (sub-part of conditional) should be a result of function
+        func foo()
+            if cond
+                ...
+                expr1 # result
+            else if cond
+                expr2 # result
+            else
+                expr3 # result
+        func foo()
+            match n
+                1 /: 10 # result
+                2
+                    20 # result
+                a :: type
+                    b = f(a)
+                    b + 30 # result
+                _
+                    50 # default result
 
 1.02 container of functions aka namespace or static methods. 
 # call


### PR DESCRIPTION
Func `iter(10, 5, -1)` with negative step, 
fix full `[:]` slice of of range `[..]` : `[1 .. 10][:]`, 
Fix range arg for list constructor  `list([1 .. 5])`
fix of return result in the match.
Tests:
```
>py -m unittest
............................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 332 tests in 2.590s

OK
```